### PR TITLE
fix: payment reconciliation shows no results

### DIFF
--- a/models/reports/payment_reconciliation.py
+++ b/models/reports/payment_reconciliation.py
@@ -54,8 +54,8 @@ def get_reconciliation_data(
         LEFT JOIN beach_packages p ON r.package_id = p.id
         LEFT JOIN beach_reservation_states rs ON r.state_id = rs.id
         WHERE r.start_date = ?
-        AND r.reservation_type IN ('paquete', 'consumo_minimo')
         AND COALESCE(rs.is_availability_releasing, 0) = 0
+        AND r.reservation_type != 'bloqueo'
     """
 
     params: list[Any] = [date]
@@ -106,8 +106,8 @@ def get_payment_summary(date: str) -> dict[str, Any]:
             FROM beach_reservations r
             LEFT JOIN beach_reservation_states rs ON r.state_id = rs.id
             WHERE r.start_date = ?
-            AND r.reservation_type IN ('paquete', 'consumo_minimo')
             AND COALESCE(rs.is_availability_releasing, 0) = 0
+            AND r.reservation_type != 'bloqueo'
             AND r.paid = 1
             GROUP BY r.payment_method
         """, (date,))
@@ -131,8 +131,8 @@ def get_payment_summary(date: str) -> dict[str, Any]:
             FROM beach_reservations r
             LEFT JOIN beach_reservation_states rs ON r.state_id = rs.id
             WHERE r.start_date = ?
-            AND r.reservation_type IN ('paquete', 'consumo_minimo')
             AND COALESCE(rs.is_availability_releasing, 0) = 0
+            AND r.reservation_type != 'bloqueo'
             AND r.paid = 0
         """, (date,))
 
@@ -148,8 +148,8 @@ def get_payment_summary(date: str) -> dict[str, Any]:
             FROM beach_reservations r
             LEFT JOIN beach_reservation_states rs ON r.state_id = rs.id
             WHERE r.start_date = ?
-            AND r.reservation_type IN ('paquete', 'consumo_minimo')
             AND COALESCE(rs.is_availability_releasing, 0) = 0
+            AND r.reservation_type != 'bloqueo'
             AND r.paid = 1
         """, (date,))
 


### PR DESCRIPTION
## Problema

La conciliación de pagos no mostraba ningún resultado.

## Causa raíz

El query filtraba `reservation_type IN ('paquete', 'consumo_minimo')`, pero el valor por defecto de `reservation_type` es `'normal'`. Las reservas solo reciben tipo `'paquete'` o `'consumo_minimo'` cuando se selecciona un paquete o aplica una política de consumo mínimo. Si no hay paquetes configurados, **todas** las reservas son `'normal'` y el reporte quedaba vacío.

## Fix

Cambiar el filtro para excluir únicamente los `'bloqueo'` (que no son reservas reales), mostrando todos los demás tipos incluyendo `'normal'`, `'paquete'` y `'consumo_minimo'`.

Afectaba las 4 queries en `models/reports/payment_reconciliation.py`.

## Test plan

- [ ] Abrir conciliación de pagos con una fecha que tenga reservas → deben aparecer
- [ ] Filtro por estado de pago (pagado/pendiente) sigue funcionando
- [ ] Las reservas de tipo `bloqueo` no aparecen
- [ ] Los totales del resumen reflejan las mismas reservas

🤖 Generated with [Claude Code](https://claude.com/claude-code)