### PR TITLE
fix: resolve furniture block overlap (#45) and orphaned reservation (#46) bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ tmpclaude-*-cwd
 .auto-claude/
 .playwright-mcp/
 NUL
+
+# Simulation database - never commit
+database/beach_club_sim.db

--- a/docs/plans/2026-02-22-simulation-bug-fixes-design.md
+++ b/docs/plans/2026-02-22-simulation-bug-fixes-design.md
@@ -1,0 +1,125 @@
+# Simulation Bug Fixes Design
+
+**Date:** 2026-02-22
+**Branch:** simulation/stress-test-2026-02
+**Related Issues:** #45 (furniture block overlap), #46 (reservations without furniture)
+
+---
+
+## Bug #45 — Furniture blocks overlap active reservations
+
+### Root Cause
+
+`create_furniture_block()` in `models/furniture_block.py` inserts directly into
+`beach_furniture_blocks` without first checking whether any active (non-releasing-state)
+reservation already has the furniture assigned on any date within the requested range.
+
+The simulation created block_id=22 on furniture_id=62 which overlapped with 5 existing
+active reservations, surfaced as a FAIL by the health check.
+
+### Fix: Pre-check conflict in `create_furniture_block`
+
+Before the `INSERT INTO beach_furniture_blocks`, add a query using the same cursor/connection:
+
+```sql
+SELECT r.ticket_number, rf.assignment_date
+FROM beach_reservation_furniture rf
+JOIN beach_reservations r ON rf.reservation_id = r.id
+WHERE rf.furniture_id = ?
+  AND rf.assignment_date BETWEEN ? AND ?
+  AND r.current_state NOT IN (<releasing_states>)
+LIMIT 5
+```
+
+Releasing states are fetched via `get_active_releasing_states()` (same source of truth
+as `check_furniture_availability_bulk`). If any conflicts are found, raise `ValueError`
+with the conflicting ticket numbers.
+
+**Files changed:** `models/furniture_block.py`
+
+---
+
+## Bug #46 — 537 reservations with no furniture assignment
+
+### Root Cause
+
+`get_db()` always returns the **same** `g.db` connection per Flask app context (stored in
+`flask.g`). Inside `create_beach_reservation`, the code opens an explicit
+`BEGIN IMMEDIATE` transaction, inserts the reservation row (uncommitted), then calls
+`check_furniture_availability_bulk()`.
+
+`check_furniture_availability_bulk` does `with get_db() as conn:` — the **same** `g.db`
+connection. When that inner `with` block exits normally, Python's `sqlite3.Connection`
+context manager protocol calls `conn.commit()`, **prematurely committing the partial outer
+transaction** (reservation row exists, no furniture assigned yet).
+
+When furniture is found to be unavailable, the subsequent `conn.rollback()` is a **no-op**
+(the transaction is already committed), so the reservation stays in the DB without any
+furniture assignment.
+
+This was confirmed by querying the sim DB: all 537 orphaned reservations are in
+`Confirmada` state and `created_by='simulation'`, matching exactly the code path where
+the availability check raises `ValueError` after the premature commit.
+
+### Fix: Pass outer connection to `check_furniture_availability_bulk`
+
+**Step 1 — `models/reservation_availability.py`:**
+
+Add optional `conn` parameter. Extract query logic into
+`_check_availability_with_conn(conn, ...)`. When `conn` is provided, use it directly
+(no context manager, no auto-commit). When `conn` is None, open normally via
+`with get_db() as conn:`.
+
+```python
+def check_furniture_availability_bulk(
+    furniture_ids, dates, exclude_reservation_id=None, conn=None
+):
+    if conn is not None:
+        return _check_availability_with_conn(conn, furniture_ids, dates, exclude_reservation_id)
+    with get_db() as conn:
+        return _check_availability_with_conn(conn, furniture_ids, dates, exclude_reservation_id)
+```
+
+**Step 2 — `models/reservation_crud.py`:**
+
+Inside `create_beach_reservation`, pass the outer `conn` to the availability check:
+
+```python
+availability = check_furniture_availability_bulk(
+    furniture_ids=furniture_ids,
+    dates=[reservation_date],
+    exclude_reservation_id=None,
+    conn=conn
+)
+```
+
+**Step 3 — `models/reservation_multiday.py`:**
+
+Inside `create_linked_multiday_reservations`, pass the outer `conn`:
+
+```python
+avail_result = check_furniture_availability_bulk(
+    all_furniture_ids, dates, conn=conn
+)
+# and per-date variant:
+avail_result = check_furniture_availability_bulk(
+    date_furniture_ids, [date], conn=conn
+)
+```
+
+**Files changed:** `models/reservation_availability.py`, `models/reservation_crud.py`,
+`models/reservation_multiday.py`
+
+---
+
+## Testing Strategy
+
+After each fix, re-run `python scripts/health_check.py --sim-db` and verify:
+- Bug #45: "Furniture blocks overlapping active reservations" → OK (0 issues)
+- Bug #46: "Active reservations with no furniture assignment" → OK (0 issues)
+
+Unit tests should cover:
+- `create_furniture_block` raises `ValueError` when active reservations exist in range
+- `create_furniture_block` succeeds when only releasing-state reservations exist in range
+- `create_beach_reservation` does NOT leave orphaned reservations when furniture is unavailable
+- `check_furniture_availability_bulk` behaves identically with and without `conn` param

--- a/docs/plans/2026-02-22-simulation-bug-fixes.md
+++ b/docs/plans/2026-02-22-simulation-bug-fixes.md
@@ -1,0 +1,815 @@
+# Simulation Bug Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix two bugs found by the stress-test health check: furniture blocks that silently overlap active reservations (#45), and reservations that get committed to the DB without furniture when availability is rejected (#46).
+
+**Architecture:** Bug #45 — add a conflict pre-check inside `create_furniture_block` using the same connection, before the INSERT. Bug #46 — refactor `check_furniture_availability_bulk` to accept an optional `conn` parameter so callers inside an active `BEGIN IMMEDIATE` transaction can pass their connection directly, preventing the nested `with get_db() as conn:` context-manager exit from prematurely committing the outer transaction.
+
+**Tech Stack:** Python 3.11, SQLite 3 (WAL mode), Flask 3 (`flask.g` single-connection-per-context), pytest
+
+---
+
+## Background: Why Bug #46 Happens
+
+`get_db()` always returns **the same** `g.db` connection within a Flask app context. Python's `sqlite3.Connection` context manager calls `conn.commit()` on a normal exit. So when `create_beach_reservation` holds an open `BEGIN IMMEDIATE` transaction and calls `check_furniture_availability_bulk`, which internally does `with get_db() as conn:` (same `g.db`), the inner `with` exit **commits the outer partial transaction** (reservation row, no furniture yet). If the availability check then finds the furniture is taken, the `conn.rollback()` is a **no-op** — the reservation is already in the DB without any furniture assignment.
+
+The fix: always pass the outer `conn` into the availability check so no nested context manager fires.
+
+---
+
+## Task 1: Fix Bug #45 — Conflict check in `create_furniture_block`
+
+**Files:**
+- Modify: `models/furniture_block.py:59-67`
+- Test: `tests/test_furniture_lock.py` (append new class)
+
+**Step 1: Write the failing test**
+
+Append this class to `tests/test_furniture_lock.py`:
+
+```python
+class TestCreateFurnitureBlockConflict:
+    """Block creation must reject furniture that has active reservations in the date range."""
+
+    def _create_furniture(self, conn, zone_id: int, number: str) -> int:
+        cursor = conn.execute(
+            "INSERT INTO beach_furniture (number, zone_id, furniture_type, capacity, active) "
+            "VALUES (?, ?, 'hamaca', 2, 1)",
+            (number, zone_id)
+        )
+        return cursor.lastrowid
+
+    def _create_customer(self, conn, email: str) -> int:
+        cursor = conn.execute(
+            "INSERT INTO beach_customers "
+            "(first_name, last_name, customer_type, email, phone, created_at) "
+            "VALUES ('Block', 'Test', 'externo', ?, '600000001', datetime('now'))",
+            (email,)
+        )
+        return cursor.lastrowid
+
+    def _assign_furniture(self, conn, furniture_id: int, date: str) -> None:
+        """Create a minimal Confirmada reservation with furniture on `date`."""
+        cust_id = self._create_customer(conn, f'blk_{date}_{furniture_id}@test.com')
+        cursor = conn.execute(
+            "INSERT INTO beach_reservations "
+            "(customer_id, ticket_number, reservation_date, start_date, end_date, "
+            " num_people, current_state, current_states, state_id, "
+            " reservation_type, created_at) "
+            "VALUES (?, ?, ?, ?, ?, 2, 'Confirmada', 'Confirmada', 1, 'normal', datetime('now'))",
+            (cust_id, f'BLKTEST{furniture_id}{date.replace("-","")}',
+             date, date, date)
+        )
+        res_id = cursor.lastrowid
+        conn.execute(
+            "INSERT INTO beach_reservation_furniture (reservation_id, furniture_id, assignment_date) "
+            "VALUES (?, ?, ?)",
+            (res_id, furniture_id, date)
+        )
+        conn.commit()
+
+    def test_raises_when_active_reservation_exists_in_range(self, app):
+        """create_furniture_block must raise ValueError when furniture is already reserved."""
+        from models.furniture_block import create_furniture_block
+
+        with app.app_context():
+            db = get_db()
+            cursor = db.cursor()
+            cursor.execute('SELECT id FROM beach_zones LIMIT 1')
+            zone_id = cursor.fetchone()['id']
+
+            furniture_id = self._create_furniture(db, zone_id, 'BLKCONFLICT01')
+            db.commit()
+
+            # Create a Confirmada reservation for '2026-07-10'
+            self._assign_furniture(db, furniture_id, '2026-07-10')
+
+            # Block overlapping that date must raise
+            with pytest.raises(ValueError, match="reservas activas"):
+                create_furniture_block(
+                    furniture_id=furniture_id,
+                    start_date='2026-07-08',
+                    end_date='2026-07-12',
+                    block_type='maintenance',
+                    created_by='test'
+                )
+
+    def test_succeeds_when_only_releasing_state_reservations_exist(self, app):
+        """Block should be allowed when conflicting reservations are all Cancelada/No-Show/Liberada."""
+        from models.furniture_block import create_furniture_block
+
+        with app.app_context():
+            db = get_db()
+            cursor = db.cursor()
+            cursor.execute('SELECT id FROM beach_zones LIMIT 1')
+            zone_id = cursor.fetchone()['id']
+
+            furniture_id = self._create_furniture(db, zone_id, 'BLKNOCONFLICT01')
+            cust_id = self._create_customer(db, 'blk_releasing@test.com')
+            db.commit()
+
+            # Create a Cancelada reservation on '2026-08-05'
+            cursor.execute(
+                "INSERT INTO beach_reservations "
+                "(customer_id, ticket_number, reservation_date, start_date, end_date, "
+                " num_people, current_state, current_states, state_id, "
+                " reservation_type, created_at) "
+                "VALUES (?, 'BLKREL01', '2026-08-05', '2026-08-05', '2026-08-05', "
+                "        2, 'Cancelada', 'Cancelada', 1, 'normal', datetime('now'))",
+                (cust_id,)
+            )
+            res_id = cursor.lastrowid
+            cursor.execute(
+                "INSERT INTO beach_reservation_furniture (reservation_id, furniture_id, assignment_date) "
+                "VALUES (?, ?, '2026-08-05')",
+                (res_id, furniture_id)
+            )
+            db.commit()
+
+            # Block on the same range must succeed (Cancelada is a releasing state)
+            block_id = create_furniture_block(
+                furniture_id=furniture_id,
+                start_date='2026-08-01',
+                end_date='2026-08-10',
+                block_type='maintenance',
+                created_by='test'
+            )
+            assert isinstance(block_id, int)
+            assert block_id > 0
+
+    def test_succeeds_when_no_reservations_in_range(self, app):
+        """Block must succeed when no reservations exist in the date range."""
+        from models.furniture_block import create_furniture_block
+
+        with app.app_context():
+            db = get_db()
+            cursor = db.cursor()
+            cursor.execute('SELECT id FROM beach_zones LIMIT 1')
+            zone_id = cursor.fetchone()['id']
+
+            furniture_id = self._create_furniture(db, zone_id, 'BLKEMPTY01')
+            db.commit()
+
+            block_id = create_furniture_block(
+                furniture_id=furniture_id,
+                start_date='2026-09-01',
+                end_date='2026-09-05',
+                block_type='vip_hold',
+                created_by='test'
+            )
+            assert isinstance(block_id, int)
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+python -m pytest tests/test_furniture_lock.py::TestCreateFurnitureBlockConflict -v
+```
+
+Expected: FAIL — `create_furniture_block` does not raise, test `test_raises_when_active_reservation_exists_in_range` fails.
+
+**Step 3: Implement the fix in `models/furniture_block.py`**
+
+Replace the `with get_db() as conn:` block (lines 59-67) with:
+
+```python
+    with get_db() as conn:
+        # Fetch releasing states directly on this connection (avoids nested context manager)
+        releasing_rows = conn.execute(
+            'SELECT name FROM beach_reservation_states WHERE is_availability_releasing = 1'
+        ).fetchall()
+        releasing_states = [row['name'] for row in releasing_rows]
+
+        # Check for active reservations that would conflict with this block
+        if releasing_states:
+            placeholders = ','.join('?' * len(releasing_states))
+            conflict_query = f'''
+                SELECT r.ticket_number
+                FROM beach_reservation_furniture rf
+                JOIN beach_reservations r ON rf.reservation_id = r.id
+                WHERE rf.furniture_id = ?
+                  AND rf.assignment_date BETWEEN ? AND ?
+                  AND r.current_state NOT IN ({placeholders})
+                LIMIT 5
+            '''
+            conflicts = conn.execute(
+                conflict_query,
+                [furniture_id, start_date, end_date] + releasing_states
+            ).fetchall()
+        else:
+            conflicts = conn.execute('''
+                SELECT r.ticket_number
+                FROM beach_reservation_furniture rf
+                JOIN beach_reservations r ON rf.reservation_id = r.id
+                WHERE rf.furniture_id = ?
+                  AND rf.assignment_date BETWEEN ? AND ?
+                LIMIT 5
+            ''', (furniture_id, start_date, end_date)).fetchall()
+
+        if conflicts:
+            tickets = ', '.join(row['ticket_number'] for row in conflicts)
+            raise ValueError(f"Mobiliario con reservas activas en estas fechas: {tickets}")
+
+        cursor = conn.execute('''
+            INSERT INTO beach_furniture_blocks
+            (furniture_id, start_date, end_date, block_type, reason, notes, created_by)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        ''', (furniture_id, start_date, end_date, block_type, reason, notes, created_by))
+
+        conn.commit()
+        return cursor.lastrowid
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+python -m pytest tests/test_furniture_lock.py::TestCreateFurnitureBlockConflict -v
+```
+
+Expected: 3 PASS.
+
+**Step 5: Run full test suite to check for regressions**
+
+```bash
+python -m pytest tests/ -x -q
+```
+
+Expected: All previously passing tests still pass.
+
+**Step 6: Commit**
+
+```bash
+git add models/furniture_block.py tests/test_furniture_lock.py
+git commit -m "fix: add active-reservation conflict check to create_furniture_block (closes #45)"
+```
+
+---
+
+## Task 2: Refactor `check_furniture_availability_bulk` to accept optional `conn`
+
+**Files:**
+- Modify: `models/reservation_availability.py:16-118`
+- Test: `tests/test_availability.py` (append new test)
+
+**Step 1: Write the failing test**
+
+Append to `tests/test_availability.py`:
+
+```python
+class TestCheckFurnitureAvailabilityBulkWithConn:
+    """check_furniture_availability_bulk must work identically with and without conn param."""
+
+    def test_accepts_conn_parameter_and_returns_same_result(self, app, setup_test_data):
+        """Passing conn= should produce identical results to calling without conn."""
+        from models.reservation_availability import check_furniture_availability_bulk
+
+        furniture_id = setup_test_data['furniture_id_1']
+
+        with app.app_context():
+            # Without conn (standalone)
+            result_standalone = check_furniture_availability_bulk(
+                furniture_ids=[furniture_id],
+                dates=['2099-01-15']
+            )
+
+            # With conn (simulating outer transaction)
+            db = get_db()
+            result_with_conn = check_furniture_availability_bulk(
+                furniture_ids=[furniture_id],
+                dates=['2099-01-15'],
+                conn=db
+            )
+
+            assert result_standalone['all_available'] == result_with_conn['all_available']
+            assert result_standalone['unavailable'] == result_with_conn['unavailable']
+
+    def test_with_conn_detects_conflict_correctly(self, app, setup_test_data):
+        """When called with conn=, conflicts are still detected correctly."""
+        from models.reservation_availability import check_furniture_availability_bulk
+
+        furniture_id = setup_test_data['furniture_id_1']
+        reservation_date = setup_test_data['date_1']
+
+        with app.app_context():
+            db = get_db()
+            result = check_furniture_availability_bulk(
+                furniture_ids=[furniture_id],
+                dates=[reservation_date],
+                conn=db
+            )
+            # furniture_id_1 has a Confirmada reservation on date_1 (from setup_test_data)
+            assert result['all_available'] is False
+            assert len(result['unavailable']) == 1
+            assert result['unavailable'][0]['furniture_id'] == furniture_id
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/test_availability.py::TestCheckFurnitureAvailabilityBulkWithConn -v
+```
+
+Expected: FAIL — `check_furniture_availability_bulk` does not accept `conn` parameter.
+
+**Step 3: Refactor `models/reservation_availability.py`**
+
+Replace the entire `check_furniture_availability_bulk` function (lines 16-118) with:
+
+```python
+def _check_availability_with_conn(
+    conn,
+    releasing_states: list,
+    furniture_ids: list,
+    dates: list,
+    exclude_reservation_id: int = None
+) -> dict:
+    """
+    Execute the availability query on an existing connection.
+    Extracted to avoid code duplication and nested context manager issues.
+    """
+    cursor = conn.cursor()
+
+    placeholders_furniture = ','.join('?' * len(furniture_ids))
+    placeholders_dates = ','.join('?' * len(dates))
+
+    query = f'''
+        SELECT rf.furniture_id, rf.assignment_date, r.id as reservation_id,
+               r.ticket_number, r.current_state,
+               f.number as furniture_number,
+               c.first_name || ' ' || COALESCE(c.last_name, '') as customer_name,
+               c.room_number
+        FROM beach_reservation_furniture rf
+        JOIN beach_reservations r ON rf.reservation_id = r.id
+        JOIN beach_customers c ON r.customer_id = c.id
+        JOIN beach_furniture f ON rf.furniture_id = f.id
+        WHERE rf.furniture_id IN ({placeholders_furniture})
+          AND rf.assignment_date IN ({placeholders_dates})
+    '''
+    params = list(furniture_ids) + list(dates)
+
+    if releasing_states:
+        placeholders_states = ','.join('?' * len(releasing_states))
+        query += f' AND r.current_state NOT IN ({placeholders_states})'
+        params.extend(releasing_states)
+
+    if exclude_reservation_id:
+        query += ' AND r.id != ?'
+        params.append(exclude_reservation_id)
+
+    cursor.execute(query, params)
+    conflicts = cursor.fetchall()
+
+    unavailable = []
+    conflict_set = set()
+
+    for row in conflicts:
+        assignment_date = row['assignment_date']
+        if hasattr(assignment_date, 'strftime'):
+            assignment_date = assignment_date.strftime('%Y-%m-%d')
+        unavailable.append({
+            'furniture_id': row['furniture_id'],
+            'furniture_number': row['furniture_number'],
+            'date': assignment_date,
+            'reservation_id': row['reservation_id'],
+            'ticket_number': row['ticket_number'],
+            'customer_name': row['customer_name'],
+            'room_number': row['room_number']
+        })
+        conflict_set.add((row['furniture_id'], assignment_date))
+
+    availability_matrix = {}
+    for date in dates:
+        availability_matrix[date] = {}
+        for furn_id in furniture_ids:
+            availability_matrix[date][furn_id] = (furn_id, date) not in conflict_set
+
+    return {
+        'all_available': len(unavailable) == 0,
+        'unavailable': unavailable,
+        'availability_matrix': availability_matrix
+    }
+
+
+def check_furniture_availability_bulk(
+    furniture_ids: list,
+    dates: list,
+    exclude_reservation_id: int = None,
+    conn=None
+) -> dict:
+    """
+    Check availability of multiple furniture items for multiple dates.
+    More efficient than calling check_furniture_availability() in a loop.
+
+    Args:
+        furniture_ids: List of furniture IDs to check
+        dates: List of dates (YYYY-MM-DD strings)
+        exclude_reservation_id: Reservation ID to exclude (for updates)
+        conn: Optional existing db connection. When provided, uses it directly
+              without opening a new context manager — prevents nested
+              with-get_db() commits from prematurely committing an outer
+              BEGIN IMMEDIATE transaction.
+
+    Returns:
+        dict: {
+            'all_available': bool,
+            'unavailable': [
+                {'furniture_id': int, 'date': str, 'reservation_id': int,
+                 'ticket_number': str, 'customer_name': str}
+            ],
+            'availability_matrix': {
+                'YYYY-MM-DD': {furniture_id: bool, ...}
+            }
+        }
+    """
+    if not furniture_ids or not dates:
+        return {
+            'all_available': True,
+            'unavailable': [],
+            'availability_matrix': {}
+        }
+
+    if conn is not None:
+        # Use provided connection — fetch releasing states on the same conn
+        # to avoid any nested context manager that would commit the outer transaction.
+        rows = conn.execute(
+            'SELECT name FROM beach_reservation_states WHERE is_availability_releasing = 1'
+        ).fetchall()
+        releasing_states = [row['name'] for row in rows]
+        return _check_availability_with_conn(
+            conn, releasing_states, furniture_ids, dates, exclude_reservation_id
+        )
+
+    # Standalone call: safe to fetch releasing states separately, then open our own conn.
+    releasing_states = get_active_releasing_states()
+    with get_db() as inner_conn:
+        return _check_availability_with_conn(
+            inner_conn, releasing_states, furniture_ids, dates, exclude_reservation_id
+        )
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+python -m pytest tests/test_availability.py -v
+```
+
+Expected: All tests pass, including the two new ones.
+
+**Step 5: Run full test suite**
+
+```bash
+python -m pytest tests/ -x -q
+```
+
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add models/reservation_availability.py tests/test_availability.py
+git commit -m "refactor: add optional conn param to check_furniture_availability_bulk to prevent nested commit"
+```
+
+---
+
+## Task 3: Pass `conn` from `create_beach_reservation`
+
+**Files:**
+- Modify: `models/reservation_crud.py` (the `check_furniture_availability_bulk` call at ~line 234)
+- Test: `tests/test_reservation.py` (append new test)
+
+**Step 1: Write the failing test**
+
+The test must show the current bug: when furniture is unavailable, `create_beach_reservation` leaves an orphaned reservation in the DB. After the fix it must not.
+
+Append to `tests/test_reservation.py`:
+
+```python
+class TestNoOrphanedReservationOnUnavailableFurniture:
+    """create_beach_reservation must not leave a reservation in the DB if furniture is taken."""
+
+    def _make_furniture(self, conn, zone_id: int, number: str) -> int:
+        cursor = conn.execute(
+            "INSERT INTO beach_furniture (number, zone_id, furniture_type, capacity, active) "
+            "VALUES (?, ?, 'hamaca', 2, 1)",
+            (number, zone_id)
+        )
+        return cursor.lastrowid
+
+    def _make_customer(self, conn, email: str) -> int:
+        cursor = conn.execute(
+            "INSERT INTO beach_customers "
+            "(first_name, last_name, customer_type, email, phone, created_at) "
+            "VALUES ('Orphan', 'Test', 'externo', ?, '600111222', datetime('now'))",
+            (email,)
+        )
+        return cursor.lastrowid
+
+    def test_no_orphaned_reservation_when_furniture_unavailable(self, app):
+        """Second reservation attempt on taken furniture must not commit a bare reservation."""
+        from models.reservation_crud import create_beach_reservation
+
+        with app.app_context():
+            db = get_db()
+            cursor = db.cursor()
+            cursor.execute('SELECT id FROM beach_zones LIMIT 1')
+            zone_id = cursor.fetchone()['id']
+
+            furniture_id = self._make_furniture(db, zone_id, 'ORPHANTEST01')
+            cust1 = self._make_customer(db, 'orphan_cust1@test.com')
+            cust2 = self._make_customer(db, 'orphan_cust2@test.com')
+            db.commit()
+
+            # First reservation takes the furniture — must succeed
+            res_id_1, _ = create_beach_reservation(
+                customer_id=cust1,
+                reservation_date='2099-06-15',
+                num_people=2,
+                furniture_ids=[furniture_id],
+                created_by='test'
+            )
+            assert res_id_1 is not None
+
+            # Count total reservations now
+            cursor.execute('SELECT COUNT(*) as cnt FROM beach_reservations')
+            count_before = cursor.fetchone()['cnt']
+
+            # Second reservation on the same furniture/date must raise
+            with pytest.raises(ValueError):
+                create_beach_reservation(
+                    customer_id=cust2,
+                    reservation_date='2099-06-15',
+                    num_people=2,
+                    furniture_ids=[furniture_id],
+                    created_by='test'
+                )
+
+            # Must not have created any extra reservation (no orphan)
+            cursor.execute('SELECT COUNT(*) as cnt FROM beach_reservations')
+            count_after = cursor.fetchone()['cnt']
+            assert count_after == count_before, (
+                f"Orphaned reservation(s) left in DB: {count_after - count_before} extra"
+            )
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest "tests/test_reservation.py::TestNoOrphanedReservationOnUnavailableFurniture" -v
+```
+
+Expected: FAIL — `count_after > count_before` (orphaned reservation exists).
+
+**Step 3: Fix `models/reservation_crud.py`**
+
+Find the call to `check_furniture_availability_bulk` inside `create_beach_reservation` (around line 234). Change it to pass `conn=conn`:
+
+```python
+            # Assign furniture (with availability check inside transaction lock)
+            if furniture_ids:
+                # Pass conn= so the check runs on the same connection/transaction.
+                # Without this, the nested with-get_db() exit would prematurely commit
+                # the outer BEGIN IMMEDIATE, leaving an orphaned reservation if furniture
+                # turns out to be unavailable.
+                availability = check_furniture_availability_bulk(
+                    furniture_ids=furniture_ids,
+                    dates=[reservation_date],
+                    exclude_reservation_id=None,
+                    conn=conn
+                )
+                if not availability.get('all_available'):
+                    unavail_items = availability.get('unavailable', [])
+                    conflict_ids = list(set(
+                        item['furniture_id'] for item in unavail_items
+                    ))
+                    conn.rollback()
+                    raise ValueError(f"Mobiliario no disponible: {conflict_ids}")
+
+                for furniture_id in furniture_ids:
+                    cursor.execute('''
+                        INSERT INTO beach_reservation_furniture
+                        (reservation_id, furniture_id, assignment_date)
+                        VALUES (?, ?, ?)
+                    ''', (reservation_id, furniture_id, reservation_date))
+```
+
+The only change is adding `conn=conn` to the `check_furniture_availability_bulk(...)` call. Everything else stays the same.
+
+**Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest "tests/test_reservation.py::TestNoOrphanedReservationOnUnavailableFurniture" -v
+```
+
+Expected: PASS.
+
+**Step 5: Run full test suite**
+
+```bash
+python -m pytest tests/ -x -q
+```
+
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add models/reservation_crud.py tests/test_reservation.py
+git commit -m "fix: pass conn to check_furniture_availability_bulk in create_beach_reservation (closes #46)"
+```
+
+---
+
+## Task 4: Pass `conn` from `create_linked_multiday_reservations`
+
+**Files:**
+- Modify: `models/reservation_multiday.py` (two calls to `check_furniture_availability_bulk` at ~lines 140 and 149)
+
+The multiday function has the same nested-context-manager problem. Fix it by passing the outer `conn`.
+
+**Step 1: Write the failing test**
+
+Append to `tests/test_reservation.py`:
+
+```python
+class TestNoOrphanedMultidayReservationOnUnavailableFurniture:
+    """create_linked_multiday_reservations must not leave orphans when furniture is taken."""
+
+    def _make_furniture(self, conn, zone_id: int, number: str) -> int:
+        cursor = conn.execute(
+            "INSERT INTO beach_furniture (number, zone_id, furniture_type, capacity, active) "
+            "VALUES (?, ?, 'hamaca', 2, 1)",
+            (number, zone_id)
+        )
+        return cursor.lastrowid
+
+    def _make_customer(self, conn, email: str) -> int:
+        cursor = conn.execute(
+            "INSERT INTO beach_customers "
+            "(first_name, last_name, customer_type, email, phone, created_at) "
+            "VALUES ('Multi', 'Test', 'externo', ?, '600333444', datetime('now'))",
+            (email,)
+        )
+        return cursor.lastrowid
+
+    def test_no_orphaned_reservation_when_multiday_furniture_unavailable(self, app):
+        """Multiday creation must roll back fully when any date's furniture is taken."""
+        from models.reservation_crud import create_beach_reservation
+        from models.reservation_multiday import create_linked_multiday_reservations
+
+        with app.app_context():
+            db = get_db()
+            cursor = db.cursor()
+            cursor.execute('SELECT id FROM beach_zones LIMIT 1')
+            zone_id = cursor.fetchone()['id']
+
+            furniture_id = self._make_furniture(db, zone_id, 'MULTIORPHAN01')
+            cust1 = self._make_customer(db, 'multi_cust1@test.com')
+            cust2 = self._make_customer(db, 'multi_cust2@test.com')
+            db.commit()
+
+            # Block furniture on day 3 of the range with a single-day reservation
+            create_beach_reservation(
+                customer_id=cust1,
+                reservation_date='2099-07-17',
+                num_people=2,
+                furniture_ids=[furniture_id],
+                created_by='test'
+            )
+
+            cursor.execute('SELECT COUNT(*) as cnt FROM beach_reservations')
+            count_before = cursor.fetchone()['cnt']
+
+            # Multiday reservation spanning 2099-07-15 to 2099-07-19 must fail
+            # because furniture is taken on 2099-07-17
+            result = create_linked_multiday_reservations(
+                customer_id=cust2,
+                dates=['2099-07-15', '2099-07-16', '2099-07-17', '2099-07-18', '2099-07-19'],
+                num_people=2,
+                furniture_ids=[furniture_id],
+                created_by='test',
+                validate_availability=True,
+                validate_duplicates=False
+            )
+            assert result['success'] is False
+
+            # No orphaned reservations must exist
+            cursor.execute('SELECT COUNT(*) as cnt FROM beach_reservations')
+            count_after = cursor.fetchone()['cnt']
+            assert count_after == count_before, (
+                f"Orphaned multiday reservation(s) in DB: {count_after - count_before} extra"
+            )
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest "tests/test_reservation.py::TestNoOrphanedMultidayReservationOnUnavailableFurniture" -v
+```
+
+Expected: FAIL or ERROR (multiday raises instead of returning `{'success': False}` in some code paths — either way, orphaned reservations may exist).
+
+**Step 3: Fix `models/reservation_multiday.py`**
+
+Find the two `check_furniture_availability_bulk` calls inside the `BEGIN IMMEDIATE` block (~lines 140 and 149). Add `conn=conn` to both:
+
+```python
+            # Validate availability (inside transaction lock)
+            if validate_availability:
+                if furniture_by_date and furniture_ids is None:
+                    for date, date_furniture_ids in furniture_by_date.items():
+                        avail_result = check_furniture_availability_bulk(
+                            date_furniture_ids, [date], conn=conn
+                        )
+                        if not avail_result['all_available']:
+                            unavail = avail_result['unavailable'][0]
+                            raise ValueError(
+                                f"Mobiliario {unavail['furniture_id']} no disponible el {unavail['date']} "
+                                f"(reserva {unavail['ticket_number']})"
+                            )
+                else:
+                    avail_result = check_furniture_availability_bulk(
+                        all_furniture_ids, dates, conn=conn
+                    )
+                    if not avail_result['all_available']:
+                        unavail = avail_result['unavailable'][0]
+                        raise ValueError(
+                            f"Mobiliario {unavail['furniture_id']} no disponible el {unavail['date']} "
+                            f"(reserva {unavail['ticket_number']})"
+                        )
+```
+
+The only change is adding `conn=conn` to both calls. Everything else stays the same.
+
+Also check how `create_linked_multiday_reservations` handles its exceptions — if it raises rather than returning `{'success': False}`, update the test to use `pytest.raises(ValueError)` and check the count similarly.
+
+**Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest "tests/test_reservation.py::TestNoOrphanedMultidayReservationOnUnavailableFurniture" -v
+```
+
+Expected: PASS (adjust test if multiday raises instead of returning success=False — see step 3 note).
+
+**Step 5: Run full test suite**
+
+```bash
+python -m pytest tests/ -x -q
+```
+
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add models/reservation_multiday.py tests/test_reservation.py
+git commit -m "fix: pass conn to check_furniture_availability_bulk in create_linked_multiday_reservations"
+```
+
+---
+
+## Task 5: Verify fixes with health check on sim DB
+
+**Files:** None modified — verification only.
+
+**Step 1: Re-run health check**
+
+```bash
+python scripts/health_check.py --sim-db
+```
+
+**Step 2: Confirm Bug #45 is resolved**
+
+Expected output line:
+```
+[OK]  Furniture blocks overlapping active reservations
+```
+(Was: `[FAIL] Furniture blocks overlapping active reservations — 5 issues`)
+
+Note: The sim DB already has the old block overlap — the fix prevents *future* blocks from conflicting. The existing overlap in the sim DB is historical data. If the health check still shows the old 5 issues, that is expected — they were created before the fix. Verify the fix works by checking the test suite instead.
+
+**Step 3: Confirm Bug #46 is resolved**
+
+Expected output line:
+```
+[OK]  Active reservations with no furniture assignment
+```
+(Was: `[WARN] Active reservations with no furniture assignment — 537 issues`)
+
+Note: The sim DB retains the 537 existing orphaned reservations. The health check will still warn about them. To confirm the fix, run a quick targeted query on a fresh sim DB OR trust the unit tests from Task 3. Alternatively, reset the sim DB and re-run the simulation:
+
+```bash
+cp instance/beach_club.db database/beach_club_sim.db
+python scripts/simulate_month.py --high-occupancy --month 2026-04 --sim-db
+python scripts/health_check.py --sim-db
+```
+
+Expected: 0 missing-furniture reservations after a fresh simulation run.
+
+**Step 4: Commit the updated report**
+
+```bash
+git add docs/simulation-report-*.md
+git commit -m "docs: update health check report after bug fixes"
+```

--- a/docs/plans/2026-02-22-simulation-stress-test-design.md
+++ b/docs/plans/2026-02-22-simulation-stress-test-design.md
@@ -1,0 +1,91 @@
+# Simulation Stress Test Design
+
+**Date:** 2026-02-22
+**Branch:** `simulation/stress-test-2026-02`
+**Approach:** Option B — Simulation + automated health-check script
+
+---
+
+## Goal
+
+Run a realistic one-month simulation at 80-100% occupancy and programmatically detect potential flaws across data integrity, business logic, and performance.
+
+---
+
+## Section 1 — Branch & Database Setup
+
+- New branch: `simulation/stress-test-2026-02`
+- Copy `database/beach_club.db` → `database/beach_club_sim.db`
+- Both scripts accept a `--sim-db` flag to target `beach_club_sim.db`
+- Add `beach_club_sim.db` to `.gitignore` — never committed
+
+---
+
+## Section 2 — Simulation Script Changes
+
+Minimal changes to `scripts/simulate_month.py`:
+
+- Add `--high-occupancy` flag: overrides `WEEKLY_OCCUPANCY` with flat `(80, 100)` every day
+- Weekdays: `(80, 100)`, Weekends: `(95, 100)`
+- Add `--month YYYY-MM` as a cleaner alternative to `--start-date`
+- Add `--sim-db` flag to point at `beach_club_sim.db`
+- All existing logic unchanged
+
+---
+
+## Section 3 — Health Check Script (`scripts/health_check.py`)
+
+New script. Runs after simulation. Checks 4 categories:
+
+### 3.1 Data Integrity
+- Double-bookings: same furniture on same date in 2+ active reservations
+- Orphaned `beach_reservation_furniture` rows (no parent reservation)
+- Missing `beach_reservation_daily_states` entries
+- Multi-day parent/child consistency (parent exists, child count matches date range)
+
+### 3.2 Business Logic
+- Invalid states for date context (e.g. `Sentada` on past dates)
+- Availability conflicts (furniture available flag vs. active reservation)
+- Pricing anomalies (`paid=1` with no `payment_method`, `charge_to_room=1` on `externo`)
+- Furniture blocks overlapping active reservations
+
+### 3.3 Performance
+- Times 6 key queries: availability check, reservation list, map load, customer search, reports, audit log
+- Warning threshold: >500ms
+- Critical threshold: >2000ms
+
+### 3.4 Report Output
+- Terminal: summary table (category → pass/warn/fail + issue count)
+- File: `docs/simulation-report-YYYY-MM-DD.md` with full per-issue details
+
+---
+
+## Section 4 — Execution Flow
+
+```bash
+# 1. Create branch
+git checkout -b simulation/stress-test-2026-02
+
+# 2. Copy production DB
+cp database/beach_club.db database/beach_club_sim.db
+
+# 3. Preview (dry run)
+python scripts/simulate_month.py --high-occupancy --month 2026-03 --sim-db --dry-run
+
+# 4. Run simulation
+python scripts/simulate_month.py --high-occupancy --month 2026-03 --sim-db
+
+# 5. Analyze
+python scripts/health_check.py --sim-db
+
+# 6. Review report
+# docs/simulation-report-YYYY-MM-DD.md
+```
+
+---
+
+## Out of Scope
+
+- No changes to `main` branch
+- `beach_club_sim.db` never committed
+- Branch archived or deleted after findings are turned into GitHub Issues

--- a/docs/plans/2026-02-22-simulation-stress-test.md
+++ b/docs/plans/2026-02-22-simulation-stress-test.md
@@ -1,0 +1,949 @@
+# Simulation Stress Test Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a branch with a stress-test simulation (80-100% occupancy for a full month) and an automated health-check script that detects data integrity, business logic, and performance flaws.
+
+**Architecture:** Modify `scripts/simulate_month.py` with `--high-occupancy`, `--month`, and `--sim-db` flags; create a standalone `scripts/health_check.py` that queries the simulation DB directly via SQLite (no Flask needed) and writes a markdown report.
+
+**Tech Stack:** Python 3.11+, SQLite3, existing Flask app context (simulation only), argparse, pathlib
+
+---
+
+## Task 1: Create Branch and Simulation Database
+
+**Files:**
+- Modify: `.gitignore`
+
+**Step 1: Create the branch**
+
+```bash
+git checkout -b simulation/stress-test-2026-02
+```
+
+Expected: `Switched to a new branch 'simulation/stress-test-2026-02'`
+
+**Step 2: Copy the production database**
+
+```bash
+cp instance/beach_club.db database/beach_club_sim.db
+```
+
+Expected: No output. Verify: `ls -lh database/beach_club_sim.db`
+
+**Step 3: Add sim DB to .gitignore**
+
+Open `.gitignore` and add at the bottom:
+
+```
+# Simulation database - never commit
+database/beach_club_sim.db
+```
+
+**Step 4: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: add simulation branch setup and gitignore for sim db"
+```
+
+---
+
+## Task 2: Add --sim-db, --high-occupancy, and --month Flags to simulate_month.py
+
+**Files:**
+- Modify: `scripts/simulate_month.py`
+
+**Context:** The current script creates `app = create_app('development')` at module level (line 50). This must be moved inside `main()` so we can set `DATABASE_PATH` env var before Flask reads it. The `--high-occupancy` flag overrides `WEEKLY_OCCUPANCY` to flat `(80, 100)` on weekdays and `(95, 100)` on weekends.
+
+**Step 1: Move app creation and add flag handling**
+
+In `scripts/simulate_month.py`, make these changes:
+
+a) **Remove** the module-level line (around line 50):
+```python
+# CREATE Flask app for context  ← DELETE THIS
+app = create_app('development')  ← DELETE THIS
+```
+
+b) **Add** a constant for the sim DB path (after the imports block, before CONSTANTS):
+```python
+SIM_DB_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'database', 'beach_club_sim.db'
+)
+
+HIGH_OCCUPANCY_WEEKDAY = (80, 100)
+HIGH_OCCUPANCY_WEEKEND = (95, 100)
+```
+
+c) **Update** `get_occupancy_target()` to accept an override:
+```python
+def get_occupancy_target(week_number: int, high_occupancy: bool = False) -> tuple:
+    """Get occupancy target range for a week."""
+    if high_occupancy:
+        return HIGH_OCCUPANCY_WEEKDAY
+    return WEEKLY_OCCUPANCY.get(week_number, (50, 70))
+```
+
+d) **Update** the occupancy section inside `run_simulation()` — find where `min_occupancy, max_occupancy = get_occupancy_target(week_num)` is called and add `high_occupancy` param. Also update the weekend boost:
+
+Find this block (around line 718-724):
+```python
+        min_occupancy, max_occupancy = get_occupancy_target(week_num)
+
+        # Weekends have higher occupancy
+        if is_weekend(current_date):
+            occupancy = random.randint(min(95, max_occupancy), min(100, max_occupancy + 10))
+        else:
+            occupancy = random.randint(min_occupancy, max_occupancy)
+```
+
+Replace with:
+```python
+        if high_occupancy and is_weekend(current_date):
+            min_occupancy, max_occupancy = HIGH_OCCUPANCY_WEEKEND
+        else:
+            min_occupancy, max_occupancy = get_occupancy_target(week_num, high_occupancy)
+
+        occupancy = random.randint(min_occupancy, max_occupancy)
+```
+
+e) **Update** `run_simulation()` signature to accept `high_occupancy`:
+```python
+def run_simulation(start_date: datetime, dry_run: bool = False, high_occupancy: bool = False) -> dict:
+```
+
+And update the header print and the occupancy loop to pass it through.
+
+f) **Update** `main()`:
+```python
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate one month of beach club simulation data'
+    )
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Preview what would be created without making changes')
+    parser.add_argument('--start-date', type=str, default=None,
+                        help='Start date for simulation (YYYY-MM-DD). Default: today')
+    parser.add_argument('--month', type=str, default=None,
+                        help='Month for simulation (YYYY-MM). Alternative to --start-date')
+    parser.add_argument('--high-occupancy', action='store_true',
+                        help='Force 80-100%% occupancy every day (stress test mode)')
+    parser.add_argument('--sim-db', action='store_true',
+                        help=f'Use simulation database: {SIM_DB_PATH}')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Show debug output including skipped reservations')
+
+    args = parser.parse_args()
+
+    # Set simulation database BEFORE creating Flask app
+    if args.sim_db:
+        if not os.path.exists(SIM_DB_PATH):
+            print(f"Error: Simulation database not found at {SIM_DB_PATH}")
+            print("Run: cp instance/beach_club.db database/beach_club_sim.db")
+            sys.exit(1)
+        os.environ['DATABASE_PATH'] = SIM_DB_PATH
+        print(f"Using simulation database: {SIM_DB_PATH}")
+
+    # Create Flask app AFTER setting DATABASE_PATH
+    from app import create_app
+    app = create_app('development')
+
+    if args.verbose:
+        logging.getLogger(__name__).setLevel(logging.DEBUG)
+
+    # Parse start date
+    if args.month:
+        try:
+            start_date = datetime.strptime(args.month, '%Y-%m')
+        except ValueError:
+            print(f"Error: Invalid month format '{args.month}'. Use YYYY-MM")
+            sys.exit(1)
+    elif args.start_date:
+        try:
+            start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
+        except ValueError:
+            print(f"Error: Invalid date format '{args.start_date}'. Use YYYY-MM-DD")
+            sys.exit(1)
+    else:
+        start_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+    with app.app_context():
+        try:
+            results = run_simulation(
+                start_date,
+                dry_run=args.dry_run,
+                high_occupancy=args.high_occupancy
+            )
+            sys.exit(0)
+        except Exception as e:
+            print(f"\nError during simulation: {e}")
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
+```
+
+g) **Remove** the module-level `from app import create_app` line (it will be imported inside `main()`).
+
+**Step 2: Test the flag parsing with dry-run**
+
+```bash
+python scripts/simulate_month.py --high-occupancy --month 2026-03 --sim-db --dry-run
+```
+
+Expected output includes:
+```
+Using simulation database: .../database/beach_club_sim.db
+...
+Mode: DRY RUN (preview only)
+...
+Week 1 complete: ... reservations, ~90% target occupancy
+Week 2 complete: ... reservations, ~90% target occupancy
+```
+
+All weeks should show ~90% target (not decreasing). If any week shows <80%, the override is broken.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/simulate_month.py
+git commit -m "feat: add --high-occupancy, --month, --sim-db flags to simulate_month.py"
+```
+
+---
+
+## Task 3: Create health_check.py — Data Integrity Checks
+
+**Files:**
+- Create: `scripts/health_check.py`
+
+**Context:** This script connects directly to SQLite (no Flask). It returns issues as a list of dicts with keys: `category`, `check`, `severity` (`ok`/`warn`/`fail`), `count`, `details` (list of strings).
+
+**Step 1: Create the file skeleton**
+
+```python
+#!/usr/bin/env python
+"""
+Beach Club Simulation Health Check.
+
+Runs after simulate_month.py to detect potential flaws in:
+- Data integrity (double bookings, orphaned records)
+- Business logic (invalid states, pricing anomalies)
+- Performance (slow queries)
+
+Usage:
+    python scripts/health_check.py --sim-db
+    python scripts/health_check.py --db-path /path/to/beach_club.db
+"""
+
+import sqlite3
+import time
+import argparse
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SIM_DB_PATH = PROJECT_ROOT / 'database' / 'beach_club_sim.db'
+REPORT_DIR = PROJECT_ROOT / 'docs'
+
+RELEASING_STATES = ('Cancelada', 'No-Show', 'Liberada')
+
+SEVERITY_COLORS = {
+    'ok': '\033[92m',    # Green
+    'warn': '\033[93m',  # Yellow
+    'fail': '\033[91m',  # Red
+    'reset': '\033[0m'
+}
+
+
+def get_connection(db_path: str) -> sqlite3.Connection:
+    """Open a read-only-style connection to the SQLite database."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute('PRAGMA journal_mode=WAL')
+    return conn
+
+
+def issue(category: str, check: str, severity: str, count: int, details: list) -> dict:
+    """Create a standardized issue dict."""
+    return {
+        'category': category,
+        'check': check,
+        'severity': severity,
+        'count': count,
+        'details': details[:20]  # Cap at 20 examples
+    }
+```
+
+**Step 2: Add data integrity checks**
+
+```python
+def check_data_integrity(conn: sqlite3.Connection) -> list:
+    """
+    Check for data integrity issues.
+
+    Returns list of issue dicts.
+    """
+    results = []
+    cur = conn.cursor()
+
+    # --- 1. Double bookings ---
+    cur.execute('''
+        SELECT rf.furniture_id, rf.assignment_date,
+               COUNT(DISTINCT rf.reservation_id) as booking_count,
+               GROUP_CONCAT(r.ticket_number, ', ') as tickets
+        FROM beach_reservation_furniture rf
+        JOIN beach_reservations r ON rf.reservation_id = r.id
+        WHERE r.current_state NOT IN (?, ?, ?)
+        GROUP BY rf.furniture_id, rf.assignment_date
+        HAVING COUNT(DISTINCT rf.reservation_id) > 1
+    ''', RELEASING_STATES)
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Data Integrity',
+        check='Double bookings (same furniture, same date)',
+        severity='fail' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"furniture_id={r['furniture_id']} on {r['assignment_date']}: "
+            f"{r['booking_count']} bookings ({r['tickets']})"
+            for r in rows
+        ]
+    ))
+
+    # --- 2. Orphaned furniture rows ---
+    cur.execute('''
+        SELECT rf.id, rf.reservation_id, rf.furniture_id, rf.assignment_date
+        FROM beach_reservation_furniture rf
+        LEFT JOIN beach_reservations r ON rf.reservation_id = r.id
+        WHERE r.id IS NULL
+    ''')
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Data Integrity',
+        check='Orphaned beach_reservation_furniture rows (no parent reservation)',
+        severity='fail' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"rf.id={r['id']} references missing reservation_id={r['reservation_id']}"
+            for r in rows
+        ]
+    ))
+
+    # --- 3. Multi-day child orphans (parent deleted) ---
+    cur.execute('''
+        SELECT r.id, r.ticket_number, r.parent_reservation_id
+        FROM beach_reservations r
+        WHERE r.parent_reservation_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM beach_reservations p
+              WHERE p.id = r.parent_reservation_id
+          )
+    ''')
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Data Integrity',
+        check='Multi-day child reservations with missing parent',
+        severity='fail' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"ticket={r['ticket_number']} references missing parent_id={r['parent_reservation_id']}"
+            for r in rows
+        ]
+    ))
+
+    # --- 4. Reservations with no furniture assignment ---
+    cur.execute('''
+        SELECT r.id, r.ticket_number, r.reservation_date, r.current_state
+        FROM beach_reservations r
+        WHERE r.current_state NOT IN (?, ?, ?)
+          AND r.reservation_type = 'normal'
+          AND NOT EXISTS (
+              SELECT 1 FROM beach_reservation_furniture rf
+              WHERE rf.reservation_id = r.id
+          )
+    ''', RELEASING_STATES)
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Data Integrity',
+        check='Active reservations with no furniture assignment',
+        severity='warn' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"ticket={r['ticket_number']} on {r['reservation_date']} ({r['current_state']})"
+            for r in rows
+        ]
+    ))
+
+    return results
+```
+
+**Step 3: Run dry-check to verify queries compile**
+
+```bash
+python -c "
+import sqlite3
+conn = sqlite3.connect('database/beach_club_sim.db')
+conn.row_factory = sqlite3.Row
+cur = conn.cursor()
+cur.execute('SELECT COUNT(*) FROM beach_reservations')
+print('Reservations:', cur.fetchone()[0])
+conn.close()
+"
+```
+
+Expected: Prints the count of reservations in the sim DB.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/health_check.py
+git commit -m "feat: add health_check.py with data integrity checks"
+```
+
+---
+
+## Task 4: Add Business Logic Checks to health_check.py
+
+**Files:**
+- Modify: `scripts/health_check.py`
+
+**Step 1: Add the business logic check function**
+
+```python
+def check_business_logic(conn: sqlite3.Connection) -> list:
+    """
+    Check for business logic violations.
+
+    Returns list of issue dicts.
+    """
+    results = []
+    cur = conn.cursor()
+
+    # --- 1. 'Sentada' state on past dates ---
+    today = datetime.now().strftime('%Y-%m-%d')
+    cur.execute('''
+        SELECT r.id, r.ticket_number, r.reservation_date, r.current_state
+        FROM beach_reservations r
+        WHERE r.current_state = 'Sentada'
+          AND r.reservation_date < ?
+    ''', (today,))
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Business Logic',
+        check="'Sentada' state on past reservation dates",
+        severity='warn' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"ticket={r['ticket_number']} on {r['reservation_date']}"
+            for r in rows
+        ]
+    ))
+
+    # --- 2. externo customer charged to room ---
+    cur.execute('''
+        SELECT r.id, r.ticket_number, c.customer_type, r.charge_to_room, r.reservation_date
+        FROM beach_reservations r
+        JOIN beach_customers c ON r.customer_id = c.id
+        WHERE c.customer_type = 'externo' AND r.charge_to_room = 1
+    ''')
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Business Logic',
+        check='External (externo) customer with charge_to_room=1',
+        severity='fail' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"ticket={r['ticket_number']} on {r['reservation_date']}"
+            for r in rows
+        ]
+    ))
+
+    # --- 3. paid=1 with no payment_method ---
+    cur.execute('''
+        SELECT id, ticket_number, reservation_date, paid, payment_method
+        FROM beach_reservations
+        WHERE paid = 1 AND (payment_method IS NULL OR payment_method = '')
+    ''')
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Business Logic',
+        check='paid=1 with no payment_method set',
+        severity='warn' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"ticket={r['ticket_number']} on {r['reservation_date']}"
+            for r in rows
+        ]
+    ))
+
+    # --- 4. Furniture blocks overlapping active reservations ---
+    cur.execute('''
+        SELECT fb.id as block_id, fb.furniture_id, fb.start_date, fb.end_date,
+               fb.block_type, rf.reservation_id, r.ticket_number, rf.assignment_date
+        FROM beach_furniture_blocks fb
+        JOIN beach_reservation_furniture rf ON rf.furniture_id = fb.furniture_id
+        JOIN beach_reservations r ON rf.reservation_id = r.id
+        WHERE rf.assignment_date BETWEEN fb.start_date AND fb.end_date
+          AND r.current_state NOT IN (?, ?, ?)
+    ''', RELEASING_STATES)
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Business Logic',
+        check='Furniture blocks overlapping active reservations',
+        severity='fail' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"block_id={r['block_id']} ({r['block_type']}) on furniture_id={r['furniture_id']} "
+            f"overlaps ticket={r['ticket_number']} on {r['assignment_date']}"
+            for r in rows
+        ]
+    ))
+
+    # --- 5. Future reservations with releasing state ---
+    cur.execute('''
+        SELECT r.id, r.ticket_number, r.reservation_date, r.current_state
+        FROM beach_reservations r
+        WHERE r.reservation_date > ?
+          AND r.current_state IN (?, ?, ?)
+    ''', (today,) + RELEASING_STATES)
+    rows = cur.fetchall()
+    # Warn only - cancelled future reservations can exist legitimately
+    results.append(issue(
+        category='Business Logic',
+        check='Future reservations with releasing state (informational)',
+        severity='warn' if len(rows) > 10 else 'ok',
+        count=len(rows),
+        details=[
+            f"ticket={r['ticket_number']} on {r['reservation_date']} ({r['current_state']})"
+            for r in rows[:5]
+        ]
+    ))
+
+    return results
+```
+
+**Step 2: Verify the new function runs without errors**
+
+```bash
+python -c "
+import sqlite3, sys, os
+sys.path.insert(0, '.')
+conn = sqlite3.connect('database/beach_club_sim.db')
+conn.row_factory = sqlite3.Row
+# Quick smoke test - just check the tables exist
+cur = conn.cursor()
+cur.execute('SELECT name FROM sqlite_master WHERE type=\"table\" AND name LIKE \"beach_%\"')
+tables = [r[0] for r in cur.fetchall()]
+print('Tables found:', len(tables))
+conn.close()
+"
+```
+
+Expected: Tables found: 15+ (varies by setup)
+
+**Step 3: Commit**
+
+```bash
+git add scripts/health_check.py
+git commit -m "feat: add business logic checks to health_check.py"
+```
+
+---
+
+## Task 5: Add Performance Checks, Report Output, and CLI to health_check.py
+
+**Files:**
+- Modify: `scripts/health_check.py`
+
+**Step 1: Add performance check function**
+
+```python
+PERF_WARN_MS = 500
+PERF_FAIL_MS = 2000
+
+
+def check_performance(db_path: str) -> list:
+    """
+    Time 6 representative queries. Returns list of issue dicts.
+    Each query gets its own fresh connection to avoid caching effects.
+    """
+    results = []
+    today = datetime.now().strftime('%Y-%m-%d')
+    month_ago = datetime.now().strftime('%Y-%m-01')
+
+    queries = [
+        (
+            'Availability check (furniture conflicts for a date)',
+            '''
+            SELECT rf.furniture_id, rf.assignment_date, r.id, r.current_state
+            FROM beach_reservation_furniture rf
+            JOIN beach_reservations r ON rf.reservation_id = r.id
+            WHERE rf.assignment_date = ? AND r.current_state NOT IN ('Cancelada','No-Show','Liberada')
+            ''',
+            (today,)
+        ),
+        (
+            'Reservation list with customer join (last 30 days)',
+            '''
+            SELECT r.id, r.ticket_number, r.reservation_date, r.current_state,
+                   c.first_name, c.last_name, c.customer_type
+            FROM beach_reservations r
+            JOIN beach_customers c ON r.customer_id = c.id
+            WHERE r.reservation_date >= ?
+            ORDER BY r.reservation_date DESC
+            ''',
+            (month_ago,)
+        ),
+        (
+            'Map load (all active furniture with today assignments)',
+            '''
+            SELECT f.id, f.number, f.zone_id, f.position_x, f.position_y,
+                   rf.reservation_id, r.current_state
+            FROM beach_furniture f
+            LEFT JOIN beach_reservation_furniture rf ON rf.furniture_id = f.id AND rf.assignment_date = ?
+            LEFT JOIN beach_reservations r ON rf.reservation_id = r.id
+                AND r.current_state NOT IN ('Cancelada','No-Show','Liberada')
+            WHERE f.is_active = 1
+            ''',
+            (today,)
+        ),
+        (
+            'Customer search (name LIKE)',
+            '''
+            SELECT id, first_name, last_name, customer_type, phone, room_number
+            FROM beach_customers
+            WHERE first_name LIKE ? OR last_name LIKE ? OR phone LIKE ?
+            LIMIT 50
+            ''',
+            ('%garcia%', '%garcia%', '%garcia%')
+        ),
+        (
+            'Daily report aggregation (reservations by date)',
+            '''
+            SELECT reservation_date, current_state, COUNT(*) as count, SUM(paid) as paid_count
+            FROM beach_reservations
+            WHERE reservation_date BETWEEN ? AND ?
+            GROUP BY reservation_date, current_state
+            ORDER BY reservation_date
+            ''',
+            (month_ago, today)
+        ),
+        (
+            'Audit log recent entries',
+            '''
+            SELECT * FROM audit_log
+            ORDER BY created_at DESC
+            LIMIT 100
+            ''',
+            ()
+        ),
+    ]
+
+    for label, query, params in queries:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+
+        start = time.perf_counter()
+        try:
+            cur = conn.cursor()
+            cur.execute(query, params)
+            rows = cur.fetchall()
+            elapsed_ms = (time.perf_counter() - start) * 1000
+
+            if elapsed_ms >= PERF_FAIL_MS:
+                severity = 'fail'
+            elif elapsed_ms >= PERF_WARN_MS:
+                severity = 'warn'
+            else:
+                severity = 'ok'
+
+            results.append(issue(
+                category='Performance',
+                check=label,
+                severity=severity,
+                count=len(rows),
+                details=[f"{elapsed_ms:.1f}ms — {len(rows)} rows returned"]
+            ))
+        except Exception as e:
+            results.append(issue(
+                category='Performance',
+                check=label,
+                severity='fail',
+                count=0,
+                details=[f"Query error: {e}"]
+            ))
+        finally:
+            conn.close()
+
+    return results
+```
+
+**Step 2: Add report output functions and main()**
+
+```python
+def print_summary(all_issues: list) -> None:
+    """Print a colour-coded summary table to stdout."""
+    c = SEVERITY_COLORS
+    print()
+    print("=" * 70)
+    print("HEALTH CHECK RESULTS")
+    print("=" * 70)
+
+    categories = {}
+    for iss in all_issues:
+        categories.setdefault(iss['category'], []).append(iss)
+
+    totals = {'ok': 0, 'warn': 0, 'fail': 0}
+
+    for category, items in categories.items():
+        print(f"\n  {category}")
+        print("  " + "-" * 60)
+        for iss in items:
+            sev = iss['severity']
+            color = c.get(sev, '')
+            icon = {'ok': '✓', 'warn': '⚠', 'fail': '✗'}.get(sev, '?')
+            totals[sev] += 1
+            count_str = f"({iss['count']} issues)" if iss['count'] > 0 else ""
+            print(f"  {color}{icon}{c['reset']} {iss['check']} {count_str}")
+            if iss['details'] and sev != 'ok':
+                for detail in iss['details'][:3]:
+                    print(f"       → {detail}")
+
+    print()
+    print("=" * 70)
+    ok_c = c['ok'] if totals['ok'] > 0 else ''
+    warn_c = c['warn'] if totals['warn'] > 0 else ''
+    fail_c = c['fail'] if totals['fail'] > 0 else ''
+    print(
+        f"  SUMMARY: "
+        f"{ok_c}✓ {totals['ok']} OK{c['reset']}  "
+        f"{warn_c}⚠ {totals['warn']} WARN{c['reset']}  "
+        f"{fail_c}✗ {totals['fail']} FAIL{c['reset']}"
+    )
+    print("=" * 70)
+
+
+def write_report(all_issues: list, db_path: str) -> str:
+    """Write a markdown report to docs/simulation-report-YYYY-MM-DD.md."""
+    report_date = datetime.now().strftime('%Y-%m-%d')
+    report_path = REPORT_DIR / f'simulation-report-{report_date}.md'
+
+    lines = [
+        f"# Simulation Health Check Report",
+        f"",
+        f"**Date:** {report_date}",
+        f"**Database:** `{db_path}`",
+        f"**Run at:** {datetime.now().strftime('%H:%M:%S')}",
+        f"",
+    ]
+
+    categories = {}
+    for iss in all_issues:
+        categories.setdefault(iss['category'], []).append(iss)
+
+    for category, items in categories.items():
+        lines.append(f"## {category}")
+        lines.append("")
+        lines.append("| Check | Severity | Issues |")
+        lines.append("|-------|----------|--------|")
+        for iss in items:
+            sev_icon = {'ok': '✅', 'warn': '⚠️', 'fail': '❌'}.get(iss['severity'], '?')
+            lines.append(f"| {iss['check']} | {sev_icon} {iss['severity'].upper()} | {iss['count']} |")
+        lines.append("")
+
+        for iss in items:
+            if iss['details'] and iss['severity'] != 'ok':
+                lines.append(f"### {iss['check']}")
+                lines.append("")
+                for detail in iss['details']:
+                    lines.append(f"- {detail}")
+                lines.append("")
+
+    report_path.write_text('\n'.join(lines), encoding='utf-8')
+    return str(report_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run health checks on beach club simulation database'
+    )
+    parser.add_argument('--sim-db', action='store_true',
+                        help=f'Use simulation database: {SIM_DB_PATH}')
+    parser.add_argument('--db-path', type=str, default=None,
+                        help='Path to SQLite database file')
+    parser.add_argument('--no-report', action='store_true',
+                        help='Skip writing the markdown report file')
+
+    args = parser.parse_args()
+
+    # Resolve database path
+    if args.db_path:
+        db_path = args.db_path
+    elif args.sim_db:
+        db_path = str(SIM_DB_PATH)
+    else:
+        print("Error: Specify --sim-db or --db-path <path>")
+        sys.exit(1)
+
+    if not os.path.exists(db_path):
+        print(f"Error: Database not found: {db_path}")
+        sys.exit(1)
+
+    print(f"\nRunning health checks on: {db_path}")
+    print(f"Database size: {os.path.getsize(db_path) / 1024 / 1024:.1f} MB")
+
+    conn = get_connection(db_path)
+    all_issues = []
+
+    print("\n[1/3] Data integrity checks...")
+    all_issues.extend(check_data_integrity(conn))
+
+    print("[2/3] Business logic checks...")
+    all_issues.extend(check_business_logic(conn))
+
+    conn.close()
+
+    print("[3/3] Performance checks...")
+    all_issues.extend(check_performance(db_path))
+
+    print_summary(all_issues)
+
+    if not args.no_report:
+        report_path = write_report(all_issues, db_path)
+        print(f"\nFull report saved to: {report_path}")
+
+    # Exit with error code if any failures
+    has_failures = any(iss['severity'] == 'fail' for iss in all_issues)
+    sys.exit(1 if has_failures else 0)
+
+
+if __name__ == '__main__':
+    main()
+```
+
+**Step 3: Test health_check runs against sim DB**
+
+```bash
+python scripts/health_check.py --sim-db --no-report
+```
+
+Expected: Completes without Python errors. If the sim DB has no data yet, all integrity checks should show `✓ 0 issues`. If it shows `Error: Database not found`, re-run Task 1 Step 2.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/health_check.py
+git commit -m "feat: add performance checks, report output, and CLI to health_check.py"
+```
+
+---
+
+## Task 6: Run the Simulation
+
+**Files:** None (data operation only)
+
+**Step 1: Preview with dry-run first**
+
+```bash
+python scripts/simulate_month.py --high-occupancy --month 2026-03 --sim-db --dry-run
+```
+
+Expected: Shows planned customers, furniture, reservations per week — all weeks at ~90% target. No DB changes made.
+
+**Step 2: Run the full simulation**
+
+```bash
+python scripts/simulate_month.py --high-occupancy --month 2026-03 --sim-db
+```
+
+Expected (approximate):
+```
+SIMULATION COMPLETE
+  Customers created: 100
+  Reservations created: 800-1200 (depends on furniture count)
+  Temporary furniture: 2-3
+  Furniture blocks: 1-2
+  Days processed: 31
+```
+
+If it errors mid-run, re-run with `--verbose` to see which reservations are being skipped and why.
+
+**Step 3: Verify data was inserted**
+
+```bash
+python -c "
+import sqlite3
+conn = sqlite3.connect('database/beach_club_sim.db')
+cur = conn.cursor()
+cur.execute('SELECT COUNT(*) FROM beach_reservations')
+print('Reservations:', cur.fetchone()[0])
+cur.execute('SELECT COUNT(*) FROM beach_customers')
+print('Customers:', cur.fetchone()[0])
+cur.execute('SELECT current_state, COUNT(*) FROM beach_reservations GROUP BY current_state')
+for row in cur.fetchall(): print(f'  {row[0]}: {row[1]}')
+conn.close()
+"
+```
+
+Expected: 800+ reservations, 100+ customers (or merged with existing), state breakdown visible.
+
+---
+
+## Task 7: Run Health Check and Review Results
+
+**Files:** None (analysis only)
+
+**Step 1: Run the health check**
+
+```bash
+python scripts/health_check.py --sim-db
+```
+
+Expected: Produces a summary table and saves `docs/simulation-report-YYYY-MM-DD.md`.
+
+**Step 2: Review the report**
+
+```bash
+cat docs/simulation-report-$(date +%Y-%m-%d).md
+```
+
+Look for:
+- **❌ FAIL items** — these are real bugs that need GitHub Issues
+- **⚠️ WARN items** — review individually; may be expected or may be worth fixing
+- **Performance items** — any query >500ms under this small dataset is a red flag
+
+**Step 3: Create GitHub Issues for any failures found**
+
+For each FAIL item:
+```bash
+gh issue create \
+  -t "bug: [description from health check]" \
+  -b "Found during stress test simulation (simulation/stress-test-2026-02 branch). Details: [paste relevant lines from report]" \
+  -l "bug,priority:high"
+```
+
+**Step 4: Commit the report**
+
+```bash
+git add docs/simulation-report-*.md
+git commit -m "docs: add simulation health check report for 2026-03"
+```
+
+---
+
+## Execution Summary
+
+```bash
+# Full workflow (copy-paste ready)
+git checkout -b simulation/stress-test-2026-02
+cp instance/beach_club.db database/beach_club_sim.db
+echo "database/beach_club_sim.db" >> .gitignore
+
+python scripts/simulate_month.py --high-occupancy --month 2026-03 --sim-db --dry-run
+python scripts/simulate_month.py --high-occupancy --month 2026-03 --sim-db
+python scripts/health_check.py --sim-db
+```

--- a/docs/simulation-report-2026-02-22.md
+++ b/docs/simulation-report-2026-02-22.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-02-22
 **Database:** `C:\Users\catia\programas\PuroBeach\PuroBeach\database\beach_club_sim.db`
-**Run at:** 13:24:03
+**Run at:** 18:20:16
 
 ## Data Integrity
 
@@ -11,30 +11,7 @@
 | Double bookings (same furniture, same date) | OK | 0 |
 | Orphaned beach_reservation_furniture rows (no parent reservation) | OK | 0 |
 | Multi-day child reservations with missing parent | OK | 0 |
-| Active reservations with no furniture assignment | WARN | 537 |
-
-### Active reservations with no furniture assignment
-
-- ticket=26030205 on 2026-03-02 (Confirmada)
-- ticket=26030206 on 2026-03-02 (Confirmada)
-- ticket=26030216 on 2026-03-02 (Confirmada)
-- ticket=26030230 on 2026-03-02 (Confirmada)
-- ticket=26030231 on 2026-03-02 (Confirmada)
-- ticket=26030240 on 2026-03-02 (Confirmada)
-- ticket=26030246 on 2026-03-02 (Confirmada)
-- ticket=26030301 on 2026-03-03 (Confirmada)
-- ticket=26030306 on 2026-03-03 (Confirmada)
-- ticket=26030310 on 2026-03-03 (Confirmada)
-- ticket=26030312 on 2026-03-03 (Confirmada)
-- ticket=26030315 on 2026-03-03 (Confirmada)
-- ticket=26030317 on 2026-03-03 (Confirmada)
-- ticket=26030330 on 2026-03-03 (Confirmada)
-- ticket=26030341 on 2026-03-03 (Confirmada)
-- ticket=26030343 on 2026-03-03 (Confirmada)
-- ticket=26030364 on 2026-03-03 (Confirmada)
-- ticket=26030367 on 2026-03-03 (Confirmada)
-- ticket=26030404 on 2026-03-04 (Confirmada)
-- ticket=26030411 on 2026-03-04 (Confirmada)
+| Active reservations with no furniture assignment | OK | 0 |
 
 ## Business Logic
 
@@ -43,32 +20,24 @@
 | 'Sentada' state on past reservation dates | OK | 0 |
 | External (externo) customer with charge_to_room=1 | OK | 0 |
 | paid=1 with no payment_method set | OK | 0 |
-| Furniture blocks overlapping active reservations | FAIL | 5 |
-| Future reservations with releasing state (informational) | WARN | 118 |
-
-### Furniture blocks overlapping active reservations
-
-- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640 on 2026-03-26
-- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640-1 on 2026-03-27
-- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640-2 on 2026-03-28
-- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640-3 on 2026-03-29
-- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640-4 on 2026-03-30
+| Furniture blocks overlapping active reservations | OK | 0 |
+| Future reservations with releasing state (informational) | WARN | 116 |
 
 ### Future reservations with releasing state (informational)
 
-- ticket=26030112 on 2026-03-01 (Cancelada)
-- ticket=26030133 on 2026-03-01 (Cancelada)
-- ticket=26030142 on 2026-03-01 (Cancelada)
-- ticket=26030149 on 2026-03-01 (Liberada)
-- ticket=26030162 on 2026-03-01 (Cancelada)
+- ticket=26040101 on 2026-04-01 (Cancelada)
+- ticket=26040108 on 2026-04-01 (Cancelada)
+- ticket=26040113 on 2026-04-01 (Cancelada)
+- ticket=26040129 on 2026-04-01 (Cancelada)
+- ticket=26040142 on 2026-04-01 (Cancelada)
 
 ## Performance
 
 | Check | Severity | Issues |
 |-------|----------|--------|
 | Availability check (furniture conflicts for a date) | OK | 2 |
-| Reservation list with customer join (last 30 days) | OK | 2664 |
-| Map load (all active furniture with today assignments) | OK | 80 |
-| Customer search (name LIKE) | OK | 2 |
+| Reservation list with customer join (last 30 days) | OK | 2151 |
+| Map load (all active furniture with today assignments) | OK | 81 |
+| Customer search (name LIKE) | OK | 3 |
 | Daily report aggregation (reservations by date) | OK | 2 |
 | Audit log recent entries | OK | 67 |

--- a/docs/simulation-report-2026-02-22.md
+++ b/docs/simulation-report-2026-02-22.md
@@ -1,0 +1,74 @@
+# Simulation Health Check Report
+
+**Date:** 2026-02-22
+**Database:** `C:\Users\catia\programas\PuroBeach\PuroBeach\database\beach_club_sim.db`
+**Run at:** 13:24:03
+
+## Data Integrity
+
+| Check | Severity | Issues |
+|-------|----------|--------|
+| Double bookings (same furniture, same date) | OK | 0 |
+| Orphaned beach_reservation_furniture rows (no parent reservation) | OK | 0 |
+| Multi-day child reservations with missing parent | OK | 0 |
+| Active reservations with no furniture assignment | WARN | 537 |
+
+### Active reservations with no furniture assignment
+
+- ticket=26030205 on 2026-03-02 (Confirmada)
+- ticket=26030206 on 2026-03-02 (Confirmada)
+- ticket=26030216 on 2026-03-02 (Confirmada)
+- ticket=26030230 on 2026-03-02 (Confirmada)
+- ticket=26030231 on 2026-03-02 (Confirmada)
+- ticket=26030240 on 2026-03-02 (Confirmada)
+- ticket=26030246 on 2026-03-02 (Confirmada)
+- ticket=26030301 on 2026-03-03 (Confirmada)
+- ticket=26030306 on 2026-03-03 (Confirmada)
+- ticket=26030310 on 2026-03-03 (Confirmada)
+- ticket=26030312 on 2026-03-03 (Confirmada)
+- ticket=26030315 on 2026-03-03 (Confirmada)
+- ticket=26030317 on 2026-03-03 (Confirmada)
+- ticket=26030330 on 2026-03-03 (Confirmada)
+- ticket=26030341 on 2026-03-03 (Confirmada)
+- ticket=26030343 on 2026-03-03 (Confirmada)
+- ticket=26030364 on 2026-03-03 (Confirmada)
+- ticket=26030367 on 2026-03-03 (Confirmada)
+- ticket=26030404 on 2026-03-04 (Confirmada)
+- ticket=26030411 on 2026-03-04 (Confirmada)
+
+## Business Logic
+
+| Check | Severity | Issues |
+|-------|----------|--------|
+| 'Sentada' state on past reservation dates | OK | 0 |
+| External (externo) customer with charge_to_room=1 | OK | 0 |
+| paid=1 with no payment_method set | OK | 0 |
+| Furniture blocks overlapping active reservations | FAIL | 5 |
+| Future reservations with releasing state (informational) | WARN | 118 |
+
+### Furniture blocks overlapping active reservations
+
+- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640 on 2026-03-26
+- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640-1 on 2026-03-27
+- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640-2 on 2026-03-28
+- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640-3 on 2026-03-29
+- block_id=22 (maintenance) on furniture_id=62 overlaps ticket=26032640-4 on 2026-03-30
+
+### Future reservations with releasing state (informational)
+
+- ticket=26030112 on 2026-03-01 (Cancelada)
+- ticket=26030133 on 2026-03-01 (Cancelada)
+- ticket=26030142 on 2026-03-01 (Cancelada)
+- ticket=26030149 on 2026-03-01 (Liberada)
+- ticket=26030162 on 2026-03-01 (Cancelada)
+
+## Performance
+
+| Check | Severity | Issues |
+|-------|----------|--------|
+| Availability check (furniture conflicts for a date) | OK | 2 |
+| Reservation list with customer join (last 30 days) | OK | 2664 |
+| Map load (all active furniture with today assignments) | OK | 80 |
+| Customer search (name LIKE) | OK | 2 |
+| Daily report aggregation (reservations by date) | OK | 2 |
+| Audit log recent entries | OK | 67 |

--- a/models/furniture_block.py
+++ b/models/furniture_block.py
@@ -48,7 +48,9 @@ def create_furniture_block(
         int: Block ID
 
     Raises:
-        ValueError: If validation fails
+        ValueError: If block_type is invalid or dates are in wrong order.
+        ValueError: If active (non-releasing) reservations exist for this
+                    furniture within the requested date range.
     """
     if block_type not in BLOCK_TYPES:
         raise ValueError(f"Tipo de bloqueo inválido: {block_type}")

--- a/models/furniture_block.py
+++ b/models/furniture_block.py
@@ -62,7 +62,7 @@ def create_furniture_block(
         # Fetch releasing states directly on this connection to avoid nested context manager.
         # (get_db() always returns the same g.db; a nested with-get_db() would commit this transaction.)
         releasing_rows = conn.execute(
-            'SELECT name FROM beach_reservation_states WHERE is_availability_releasing = 1'
+            'SELECT name FROM beach_reservation_states WHERE is_availability_releasing = 1 AND active = 1'
         ).fetchall()
         releasing_states = [row['name'] for row in releasing_rows]
 

--- a/models/reservation_availability.py
+++ b/models/reservation_availability.py
@@ -13,10 +13,85 @@ from .reservation_state import get_active_releasing_states
 # BULK AVAILABILITY
 # =============================================================================
 
-def check_furniture_availability_bulk(
+def _check_availability_with_conn(
+    conn,
+    releasing_states: list,
     furniture_ids: list,
     dates: list,
     exclude_reservation_id: int = None
+) -> dict:
+    """
+    Execute the availability query on an existing connection.
+    Accepts pre-fetched releasing_states to avoid nested context manager calls.
+    """
+    cursor = conn.cursor()
+
+    placeholders_furniture = ','.join('?' * len(furniture_ids))
+    placeholders_dates = ','.join('?' * len(dates))
+
+    query = f'''
+        SELECT rf.furniture_id, rf.assignment_date, r.id as reservation_id,
+               r.ticket_number, r.current_state,
+               f.number as furniture_number,
+               c.first_name || ' ' || COALESCE(c.last_name, '') as customer_name,
+               c.room_number
+        FROM beach_reservation_furniture rf
+        JOIN beach_reservations r ON rf.reservation_id = r.id
+        JOIN beach_customers c ON r.customer_id = c.id
+        JOIN beach_furniture f ON rf.furniture_id = f.id
+        WHERE rf.furniture_id IN ({placeholders_furniture})
+          AND rf.assignment_date IN ({placeholders_dates})
+    '''
+    params = list(furniture_ids) + list(dates)
+
+    if releasing_states:
+        placeholders_states = ','.join('?' * len(releasing_states))
+        query += f' AND r.current_state NOT IN ({placeholders_states})'
+        params.extend(releasing_states)
+
+    if exclude_reservation_id:
+        query += ' AND r.id != ?'
+        params.append(exclude_reservation_id)
+
+    cursor.execute(query, params)
+    conflicts = cursor.fetchall()
+
+    unavailable = []
+    conflict_set = set()
+
+    for row in conflicts:
+        assignment_date = row['assignment_date']
+        if hasattr(assignment_date, 'strftime'):
+            assignment_date = assignment_date.strftime('%Y-%m-%d')
+        unavailable.append({
+            'furniture_id': row['furniture_id'],
+            'furniture_number': row['furniture_number'],
+            'date': assignment_date,
+            'reservation_id': row['reservation_id'],
+            'ticket_number': row['ticket_number'],
+            'customer_name': row['customer_name'],
+            'room_number': row['room_number']
+        })
+        conflict_set.add((row['furniture_id'], assignment_date))
+
+    availability_matrix = {}
+    for date in dates:
+        availability_matrix[date] = {}
+        for furn_id in furniture_ids:
+            availability_matrix[date][furn_id] = (furn_id, date) not in conflict_set
+
+    return {
+        'all_available': len(unavailable) == 0,
+        'unavailable': unavailable,
+        'availability_matrix': availability_matrix
+    }
+
+
+def check_furniture_availability_bulk(
+    furniture_ids: list,
+    dates: list,
+    exclude_reservation_id: int = None,
+    conn=None
 ) -> dict:
     """
     Check availability of multiple furniture items for multiple dates.
@@ -26,6 +101,10 @@ def check_furniture_availability_bulk(
         furniture_ids: List of furniture IDs to check
         dates: List of dates (YYYY-MM-DD strings)
         exclude_reservation_id: Reservation ID to exclude (for updates)
+        conn: Optional existing db connection. When provided, uses it directly
+              without opening a new context manager — prevents nested
+              with-get_db() commits from prematurely committing an outer
+              BEGIN IMMEDIATE transaction.
 
     Returns:
         dict: {
@@ -46,76 +125,24 @@ def check_furniture_availability_bulk(
             'availability_matrix': {}
         }
 
-    with get_db() as conn:
-        cursor = conn.cursor()
+    if conn is not None:
+        # Use provided connection — fetch releasing states on the same conn
+        # to avoid any nested context manager that would commit the outer transaction.
+        rows = conn.execute(
+            'SELECT name FROM beach_reservation_states WHERE is_availability_releasing = 1'
+        ).fetchall()
+        releasing_states = [row['name'] for row in rows]
+        return _check_availability_with_conn(
+            conn, releasing_states, furniture_ids, dates, exclude_reservation_id
+        )
 
-        releasing_states = get_active_releasing_states()
-
-        # Build query to find all conflicts
-        placeholders_furniture = ','.join('?' * len(furniture_ids))
-        placeholders_dates = ','.join('?' * len(dates))
-
-        query = f'''
-            SELECT rf.furniture_id, rf.assignment_date, r.id as reservation_id,
-                   r.ticket_number, r.current_state,
-                   f.number as furniture_number,
-                   c.first_name || ' ' || COALESCE(c.last_name, '') as customer_name,
-                   c.room_number
-            FROM beach_reservation_furniture rf
-            JOIN beach_reservations r ON rf.reservation_id = r.id
-            JOIN beach_customers c ON r.customer_id = c.id
-            JOIN beach_furniture f ON rf.furniture_id = f.id
-            WHERE rf.furniture_id IN ({placeholders_furniture})
-              AND rf.assignment_date IN ({placeholders_dates})
-        '''
-        params = list(furniture_ids) + list(dates)
-
-        # Exclude releasing states (Cancelada, No-Show, Liberada)
-        if releasing_states:
-            placeholders_states = ','.join('?' * len(releasing_states))
-            query += f' AND r.current_state NOT IN ({placeholders_states})'
-            params.extend(releasing_states)
-
-        # Exclude specific reservation (for updates)
-        if exclude_reservation_id:
-            query += ' AND r.id != ?'
-            params.append(exclude_reservation_id)
-
-        cursor.execute(query, params)
-        conflicts = cursor.fetchall()
-
-        # Build unavailable list
-        # Note: assignment_date may be returned as datetime.date object, convert to string
-        unavailable = []
-        conflict_set = set()  # (furniture_id, date) tuples
-
-        for row in conflicts:
-            assignment_date = row['assignment_date']
-            if hasattr(assignment_date, 'strftime'):
-                assignment_date = assignment_date.strftime('%Y-%m-%d')
-            unavailable.append({
-                'furniture_id': row['furniture_id'],
-                'furniture_number': row['furniture_number'],
-                'date': assignment_date,
-                'reservation_id': row['reservation_id'],
-                'ticket_number': row['ticket_number'],
-                'customer_name': row['customer_name'],
-                'room_number': row['room_number']
-            })
-            conflict_set.add((row['furniture_id'], assignment_date))
-
-        # Build availability matrix
-        availability_matrix = {}
-        for date in dates:
-            availability_matrix[date] = {}
-            for furn_id in furniture_ids:
-                availability_matrix[date][furn_id] = (furn_id, date) not in conflict_set
-
-        return {
-            'all_available': len(unavailable) == 0,
-            'unavailable': unavailable,
-            'availability_matrix': availability_matrix
-        }
+    # Standalone call: safe to fetch releasing states via get_active_releasing_states()
+    # since there is no outer transaction to disturb.
+    releasing_states = get_active_releasing_states()
+    with get_db() as inner_conn:
+        return _check_availability_with_conn(
+            inner_conn, releasing_states, furniture_ids, dates, exclude_reservation_id
+        )
 
 
 # =============================================================================

--- a/models/reservation_availability.py
+++ b/models/reservation_availability.py
@@ -5,6 +5,8 @@ Handles efficient multi-furniture/multi-date availability queries.
 Phase 6B - Module 1
 """
 
+import sqlite3
+
 from database import get_db
 from .reservation_state import get_active_releasing_states
 
@@ -14,7 +16,7 @@ from .reservation_state import get_active_releasing_states
 # =============================================================================
 
 def _check_availability_with_conn(
-    conn,
+    conn: sqlite3.Connection,
     releasing_states: list,
     furniture_ids: list,
     dates: list,
@@ -91,7 +93,7 @@ def check_furniture_availability_bulk(
     furniture_ids: list,
     dates: list,
     exclude_reservation_id: int = None,
-    conn=None
+    conn: sqlite3.Connection | None = None
 ) -> dict:
     """
     Check availability of multiple furniture items for multiple dates.
@@ -129,7 +131,7 @@ def check_furniture_availability_bulk(
         # Use provided connection — fetch releasing states on the same conn
         # to avoid any nested context manager that would commit the outer transaction.
         rows = conn.execute(
-            'SELECT name FROM beach_reservation_states WHERE is_availability_releasing = 1'
+            'SELECT name FROM beach_reservation_states WHERE is_availability_releasing = 1 AND active = 1'
         ).fetchall()
         releasing_states = [row['name'] for row in rows]
         return _check_availability_with_conn(

--- a/models/reservation_crud.py
+++ b/models/reservation_crud.py
@@ -462,10 +462,14 @@ def update_reservation_with_furniture(
             availability = check_furniture_availability_bulk(
                 furniture_ids=furniture_ids,
                 dates=[res_date],
-                exclude_reservation_id=reservation_id
+                exclude_reservation_id=reservation_id,
+                conn=conn
             )
-            if availability.get('conflicts'):
-                conflict_ids = list(availability['conflicts'].keys())
+            if availability.get('unavailable'):
+                unavail_items = availability['unavailable']
+                conflict_ids = list(set(
+                    item['furniture_id'] for item in unavail_items
+                ))
                 raise ValueError(f"Mobiliario no disponible: {conflict_ids}")
 
             # Clear existing assignments

--- a/models/reservation_crud.py
+++ b/models/reservation_crud.py
@@ -234,7 +234,8 @@ def create_beach_reservation(
                 availability = check_furniture_availability_bulk(
                     furniture_ids=furniture_ids,
                     dates=[reservation_date],
-                    exclude_reservation_id=None
+                    exclude_reservation_id=None,
+                    conn=conn   # pass outer transaction conn to prevent premature commit
                 )
                 if not availability.get('all_available'):
                     unavail_items = availability.get('unavailable', [])

--- a/models/reservation_multiday.py
+++ b/models/reservation_multiday.py
@@ -137,7 +137,7 @@ def create_linked_multiday_reservations(
                     # Per-date availability check when using furniture_by_date
                     # Each date has specific furniture, check only those for that date
                     for date, date_furniture_ids in furniture_by_date.items():
-                        avail_result = check_furniture_availability_bulk(date_furniture_ids, [date])
+                        avail_result = check_furniture_availability_bulk(date_furniture_ids, [date], conn=conn)
                         if not avail_result['all_available']:
                             unavail = avail_result['unavailable'][0]
                             raise ValueError(
@@ -146,7 +146,7 @@ def create_linked_multiday_reservations(
                             )
                 else:
                     # Same furniture for all days - check all against all
-                    avail_result = check_furniture_availability_bulk(all_furniture_ids, dates)
+                    avail_result = check_furniture_availability_bulk(all_furniture_ids, dates, conn=conn)
                     if not avail_result['all_available']:
                         unavail = avail_result['unavailable'][0]
                         raise ValueError(

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+"""
+Beach Club Simulation Health Check.
+
+Runs after simulate_month.py to detect potential flaws in:
+- Data integrity (double bookings, orphaned records)
+- Business logic (invalid states, pricing anomalies)
+- Performance (slow queries)
+
+Usage:
+    python scripts/health_check.py --sim-db
+    python scripts/health_check.py --db-path /path/to/beach_club.db
+"""
+
+import sqlite3
+import time
+import argparse
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SIM_DB_PATH = PROJECT_ROOT / 'database' / 'beach_club_sim.db'
+REPORT_DIR = PROJECT_ROOT / 'docs'
+
+RELEASING_STATES = ('Cancelada', 'No-Show', 'Liberada')
+
+SEVERITY_COLORS = {
+    'ok': '\033[92m',    # Green
+    'warn': '\033[93m',  # Yellow
+    'fail': '\033[91m',  # Red
+    'reset': '\033[0m'
+}
+
+
+def get_connection(db_path: str) -> sqlite3.Connection:
+    """Open a connection to the SQLite database."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute('PRAGMA journal_mode=WAL')
+    return conn
+
+
+def issue(category: str, check: str, severity: str, count: int, details: list) -> dict:
+    """Create a standardized issue dict."""
+    return {
+        'category': category,
+        'check': check,
+        'severity': severity,
+        'count': count,
+        'details': details[:20]  # Cap at 20 examples
+    }
+
+
+def check_data_integrity(conn: sqlite3.Connection) -> list:
+    """
+    Check for data integrity issues.
+
+    Returns list of issue dicts.
+    """
+    results = []
+    cur = conn.cursor()
+
+    # --- 1. Double bookings ---
+    cur.execute('''
+        SELECT rf.furniture_id, rf.assignment_date,
+               COUNT(DISTINCT rf.reservation_id) as booking_count,
+               GROUP_CONCAT(r.ticket_number, ', ') as tickets
+        FROM beach_reservation_furniture rf
+        JOIN beach_reservations r ON rf.reservation_id = r.id
+        WHERE r.current_state NOT IN (?, ?, ?)
+        GROUP BY rf.furniture_id, rf.assignment_date
+        HAVING COUNT(DISTINCT rf.reservation_id) > 1
+    ''', RELEASING_STATES)
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Data Integrity',
+        check='Double bookings (same furniture, same date)',
+        severity='fail' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"furniture_id={r['furniture_id']} on {r['assignment_date']}: "
+            f"{r['booking_count']} bookings ({r['tickets']})"
+            for r in rows
+        ]
+    ))
+
+    # --- 2. Orphaned furniture rows ---
+    cur.execute('''
+        SELECT rf.id, rf.reservation_id, rf.furniture_id, rf.assignment_date
+        FROM beach_reservation_furniture rf
+        LEFT JOIN beach_reservations r ON rf.reservation_id = r.id
+        WHERE r.id IS NULL
+    ''')
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Data Integrity',
+        check='Orphaned beach_reservation_furniture rows (no parent reservation)',
+        severity='fail' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"rf.id={r['id']} references missing reservation_id={r['reservation_id']}"
+            for r in rows
+        ]
+    ))
+
+    # --- 3. Multi-day child orphans (parent deleted) ---
+    cur.execute('''
+        SELECT r.id, r.ticket_number, r.parent_reservation_id
+        FROM beach_reservations r
+        WHERE r.parent_reservation_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM beach_reservations p
+              WHERE p.id = r.parent_reservation_id
+          )
+    ''')
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Data Integrity',
+        check='Multi-day child reservations with missing parent',
+        severity='fail' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"ticket={r['ticket_number']} references missing parent_id={r['parent_reservation_id']}"
+            for r in rows
+        ]
+    ))
+
+    # --- 4. Reservations with no furniture assignment ---
+    cur.execute('''
+        SELECT r.id, r.ticket_number, r.reservation_date, r.current_state
+        FROM beach_reservations r
+        WHERE r.current_state NOT IN (?, ?, ?)
+          AND r.reservation_type = 'normal'
+          AND NOT EXISTS (
+              SELECT 1 FROM beach_reservation_furniture rf
+              WHERE rf.reservation_id = r.id
+          )
+    ''', RELEASING_STATES)
+    rows = cur.fetchall()
+    results.append(issue(
+        category='Data Integrity',
+        check='Active reservations with no furniture assignment',
+        severity='warn' if rows else 'ok',
+        count=len(rows),
+        details=[
+            f"ticket={r['ticket_number']} on {r['reservation_date']} ({r['current_state']})"
+            for r in rows
+        ]
+    ))
+
+    return results
+
+
+def check_business_logic(conn: sqlite3.Connection) -> list:
+    """Business logic checks — implemented in Task 4."""
+    return []
+
+
+def check_performance(db_path: str) -> list:
+    """Performance checks — implemented in Task 5."""
+    return []
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run health checks on beach club simulation database'
+    )
+    parser.add_argument('--sim-db', action='store_true',
+                        help=f'Use simulation database: {SIM_DB_PATH}')
+    parser.add_argument('--db-path', type=str, default=None,
+                        help='Path to SQLite database file')
+    args = parser.parse_args()
+
+    if args.db_path:
+        db_path = args.db_path
+    elif args.sim_db:
+        db_path = str(SIM_DB_PATH)
+    else:
+        print("Error: Specify --sim-db or --db-path <path>")
+        sys.exit(1)
+
+    if not os.path.exists(db_path):
+        print(f"Error: Database not found: {db_path}")
+        sys.exit(1)
+
+    conn = get_connection(db_path)
+    results = check_data_integrity(conn)
+    conn.close()
+
+    for r in results:
+        icon = {'ok': '[OK]', 'warn': '[WARN]', 'fail': '[FAIL]'}.get(r['severity'], '[?]')
+        print(f"{icon} {r['check']} ({r['count']} issues)")
+        for d in r['details'][:3]:
+            print(f"    -> {d}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -410,9 +410,14 @@ def print_summary(all_issues: list) -> None:
             color = c.get(sev, '')
             icon = {'ok': '[OK]', 'warn': '[WARN]', 'fail': '[FAIL]'}.get(sev, '[?]')
             totals[sev] += 1
-            count_str = f"({iss['count']} issues)" if iss['count'] > 0 else ''
+            # For performance checks, details already contain timing info — skip the count label
+            if iss['category'] != 'Performance' and iss['count'] > 0:
+                count_str = f"({iss['count']} issues)"
+            else:
+                count_str = ''
             print(f"  {color}{icon}{c['reset']} {iss['check']} {count_str}")
-            if iss['details'] and sev != 'ok':
+            # Always show details for performance checks (timing info), only for non-ok otherwise
+            if iss['details'] and (iss['category'] == 'Performance' or sev != 'ok'):
                 for detail in iss['details'][:3]:
                     print(f"       -> {detail}")
 
@@ -467,6 +472,7 @@ def write_report(all_issues: list, db_path: str) -> str:
                     lines.append(f'- {detail}')
                 lines.append('')
 
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
     report_path.write_text('\n'.join(lines), encoding='utf-8')
     return str(report_path)
 

--- a/scripts/simulate_month.py
+++ b/scripts/simulate_month.py
@@ -12,6 +12,9 @@ Usage:
     python scripts/simulate_month.py                    # Run simulation
     python scripts/simulate_month.py --dry-run          # Preview what would be created
     python scripts/simulate_month.py --start-date 2026-02-01  # Custom start date
+    python scripts/simulate_month.py --month 2026-03    # Simulate specific month
+    python scripts/simulate_month.py --high-occupancy   # Force 80-100% occupancy
+    python scripts/simulate_month.py --sim-db           # Use simulation database
 """
 
 import sys
@@ -32,9 +35,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Import app factory for context
-from app import create_app
-
 # These imports must happen after path setup
 from database import get_db
 from models.customer_crud import create_customer, get_all_customers
@@ -46,8 +46,18 @@ from models.furniture_daily import create_temporary_furniture, get_next_temp_fur
 from models.furniture_block import create_furniture_block
 from models.zone import get_all_zones
 
-# Create Flask app for database context
-app = create_app('development')
+
+# =============================================================================
+# SIMULATION DATABASE PATH
+# =============================================================================
+
+SIM_DB_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'database', 'beach_club_sim.db'
+)
+
+HIGH_OCCUPANCY_WEEKDAY = (80, 100)
+HIGH_OCCUPANCY_WEEKEND = (95, 100)
 
 
 # =============================================================================
@@ -150,8 +160,10 @@ def weighted_choice(options: dict):
     return random.choices(items, weights=weights, k=1)[0]
 
 
-def get_occupancy_target(week_number: int) -> tuple:
+def get_occupancy_target(week_number: int, high_occupancy: bool = False) -> tuple:
     """Get occupancy target range for a week."""
+    if high_occupancy:
+        return HIGH_OCCUPANCY_WEEKDAY
     return WEEKLY_OCCUPANCY.get(week_number, (50, 70))
 
 
@@ -326,7 +338,7 @@ def generate_reservations_for_date(
                 charge_to_room = 0
 
             paid = 1 if payment_method else 0
-            num_people = random.randint(1, min(4, furn.get('capacity', 4)))
+            num_people = random.randint(1, max(1, min(4, furn.get('capacity', 4))))
 
             if not dry_run:
                 try:
@@ -369,7 +381,7 @@ def generate_reservations_for_date(
                 charge_to_room = 0
 
             paid = 1 if payment_method else 0
-            num_people = random.randint(1, min(4, furn.get('capacity', 4)))
+            num_people = random.randint(1, max(1, min(4, furn.get('capacity', 4))))
 
             if not dry_run:
                 try:
@@ -417,7 +429,7 @@ def generate_reservations_for_date(
                 charge_to_room = 0
 
             paid = 1 if payment_method else 0
-            num_people = random.randint(1, min(4, furn.get('capacity', 4)))
+            num_people = random.randint(1, max(1, min(4, furn.get('capacity', 4))))
 
             if not dry_run:
                 try:
@@ -620,13 +632,14 @@ def generate_furniture_blocks(
 # MAIN SIMULATION
 # =============================================================================
 
-def run_simulation(start_date: datetime, dry_run: bool = False) -> dict:
+def run_simulation(start_date: datetime, dry_run: bool = False, high_occupancy: bool = False) -> dict:
     """
     Run the full month simulation.
 
     Args:
         start_date: Simulation start date
         dry_run: If True, don't actually create anything
+        high_occupancy: If True, force 80-100% occupancy every day
 
     Returns:
         Summary of created data
@@ -640,6 +653,7 @@ def run_simulation(start_date: datetime, dry_run: bool = False) -> dict:
     print(f"Start Date: {start_date.strftime('%Y-%m-%d')}")
     print(f"End Date: {end_date.strftime('%Y-%m-%d')}")
     print(f"Mode: {'DRY RUN (preview only)' if dry_run else 'LIVE'}")
+    print(f"High Occupancy: {'YES (80-100% weekdays, 95-100% weekends)' if high_occupancy else 'NO (normal pattern)'}")
     print("=" * 60)
     print()
 
@@ -705,7 +719,7 @@ def run_simulation(start_date: datetime, dry_run: bool = False) -> dict:
         # Track weekly progress
         if week_num != current_week:
             if current_week > 0:
-                min_occ, max_occ = get_occupancy_target(current_week)
+                min_occ, max_occ = get_occupancy_target(current_week, high_occupancy)
                 target_avg = (min_occ + max_occ) / 2
                 results['weekly_stats'][current_week] = week_reservations
                 print(f"  Week {current_week} complete: {week_reservations} reservations, ~{int(target_avg)}% target occupancy")
@@ -715,13 +729,12 @@ def run_simulation(start_date: datetime, dry_run: bool = False) -> dict:
             week_start = current_date
 
         # Get occupancy target for current week
-        min_occupancy, max_occupancy = get_occupancy_target(week_num)
-
-        # Weekends have higher occupancy
-        if is_weekend(current_date):
-            occupancy = random.randint(min(95, max_occupancy), min(100, max_occupancy + 10))
+        if high_occupancy and is_weekend(current_date):
+            min_occupancy, max_occupancy = HIGH_OCCUPANCY_WEEKEND
         else:
-            occupancy = random.randint(min_occupancy, max_occupancy)
+            min_occupancy, max_occupancy = get_occupancy_target(week_num, high_occupancy)
+
+        occupancy = random.randint(min_occupancy, max_occupancy)
 
         # Reload furniture for this date (to include temp furniture)
         date_str = current_date.strftime('%Y-%m-%d')
@@ -746,7 +759,7 @@ def run_simulation(start_date: datetime, dry_run: bool = False) -> dict:
 
     # Final week stats
     if current_week > 0:
-        min_occ, max_occ = get_occupancy_target(current_week)
+        min_occ, max_occ = get_occupancy_target(current_week, high_occupancy)
         target_avg = (min_occ + max_occ) / 2
         results['weekly_stats'][current_week] = week_reservations
         print(f"  Week {current_week} complete: {week_reservations} reservations, ~{int(target_avg)}% target occupancy")
@@ -775,31 +788,45 @@ def main():
     parser = argparse.ArgumentParser(
         description='Generate one month of beach club simulation data'
     )
-    parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Preview what would be created without making changes'
-    )
-    parser.add_argument(
-        '--start-date',
-        type=str,
-        default=None,
-        help='Start date for simulation (YYYY-MM-DD). Default: today'
-    )
-    parser.add_argument(
-        '--verbose', '-v',
-        action='store_true',
-        help='Show debug output including skipped reservations'
-    )
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Preview what would be created without making changes')
+    parser.add_argument('--start-date', type=str, default=None,
+                        help='Start date for simulation (YYYY-MM-DD). Default: today')
+    parser.add_argument('--month', type=str, default=None,
+                        help='Month for simulation (YYYY-MM). Alternative to --start-date')
+    parser.add_argument('--high-occupancy', action='store_true',
+                        help='Force 80-100%% occupancy every day (stress test mode)')
+    parser.add_argument('--sim-db', action='store_true',
+                        help=f'Use simulation database: {SIM_DB_PATH}')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Show debug output including skipped reservations')
 
     args = parser.parse_args()
 
-    # Set logging level based on verbosity
+    # Set simulation database BEFORE creating Flask app
+    if args.sim_db:
+        if not os.path.exists(SIM_DB_PATH):
+            print(f"Error: Simulation database not found at {SIM_DB_PATH}")
+            print("Run: cp instance/beach_club.db database/beach_club_sim.db")
+            sys.exit(1)
+        os.environ['DATABASE_PATH'] = SIM_DB_PATH
+        print(f"Using simulation database: {SIM_DB_PATH}")
+
+    # Create Flask app AFTER setting DATABASE_PATH
+    from app import create_app
+    app = create_app('development')
+
     if args.verbose:
         logging.getLogger(__name__).setLevel(logging.DEBUG)
 
     # Parse start date
-    if args.start_date:
+    if args.month:
+        try:
+            start_date = datetime.strptime(args.month, '%Y-%m')
+        except ValueError:
+            print(f"Error: Invalid month format '{args.month}'. Use YYYY-MM")
+            sys.exit(1)
+    elif args.start_date:
         try:
             start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
         except ValueError:
@@ -808,10 +835,13 @@ def main():
     else:
         start_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # Run simulation within Flask app context
     with app.app_context():
         try:
-            results = run_simulation(start_date, dry_run=args.dry_run)
+            results = run_simulation(
+                start_date,
+                dry_run=args.dry_run,
+                high_occupancy=args.high_occupancy
+            )
             sys.exit(0)
         except Exception as e:
             print(f"\nError during simulation: {e}")

--- a/scripts/simulate_month.py
+++ b/scripts/simulate_month.py
@@ -48,7 +48,7 @@ from models.zone import get_all_zones
 
 
 # =============================================================================
-# SIMULATION DATABASE PATH
+# SIMULATION CONSTANTS
 # =============================================================================
 
 SIM_DB_PATH = os.path.join(
@@ -802,6 +802,10 @@ def main():
                         help='Show debug output including skipped reservations')
 
     args = parser.parse_args()
+
+    if args.month and args.start_date:
+        print("Error: --month and --start-date are mutually exclusive. Use one or the other.")
+        sys.exit(1)
 
     # Set simulation database BEFORE creating Flask app
     if args.sim_db:

--- a/tests/test_furniture_lock.py
+++ b/tests/test_furniture_lock.py
@@ -396,14 +396,16 @@ class TestCreateFurnitureBlockConflict:
     def _assign_furniture(self, conn, furniture_id: int, date: str) -> None:
         """Create a minimal Confirmada reservation with furniture on `date`."""
         cust_id = self._create_customer(conn, f'blk_{date}_{furniture_id}@test.com')
+        state_row = conn.execute("SELECT id FROM beach_reservation_states LIMIT 1").fetchone()
+        state_id = state_row['id'] if state_row else 1
         cursor = conn.execute(
             "INSERT INTO beach_reservations "
             "(customer_id, ticket_number, reservation_date, start_date, end_date, "
             " num_people, current_state, current_states, state_id, "
             " reservation_type, created_at) "
-            "VALUES (?, ?, ?, ?, ?, 2, 'Confirmada', 'Confirmada', 1, 'normal', datetime('now'))",
+            "VALUES (?, ?, ?, ?, ?, 2, 'Confirmada', 'Confirmada', ?, 'normal', datetime('now'))",
             (cust_id, f'BLKTEST{furniture_id}{date.replace("-","")}',
-             date, date, date)
+             date, date, date, state_id)
         )
         res_id = cursor.lastrowid
         conn.execute(
@@ -454,14 +456,16 @@ class TestCreateFurnitureBlockConflict:
             db.commit()
 
             # Create a Cancelada reservation on '2026-08-05'
+            state_row = db.execute("SELECT id FROM beach_reservation_states LIMIT 1").fetchone()
+            state_id = state_row['id'] if state_row else 1
             cursor.execute(
                 "INSERT INTO beach_reservations "
                 "(customer_id, ticket_number, reservation_date, start_date, end_date, "
                 " num_people, current_state, current_states, state_id, "
                 " reservation_type, created_at) "
                 "VALUES (?, 'BLKREL01', '2026-08-05', '2026-08-05', '2026-08-05', "
-                "        2, 'Cancelada', 'Cancelada', 1, 'normal', datetime('now'))",
-                (cust_id,)
+                "        2, 'Cancelada', 'Cancelada', ?, 'normal', datetime('now'))",
+                (cust_id, state_id)
             )
             res_id = cursor.lastrowid
             cursor.execute(

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -561,8 +561,8 @@ class TestNoOrphanedReservationOnUnavailableFurniture:
         cursor = conn.execute(
             "INSERT INTO beach_customers "
             "(first_name, last_name, customer_type, email, phone, created_at) "
-            "VALUES ('Orphan', 'Test', 'externo', ?, '600111222', datetime('now'))",
-            (email,)
+            "VALUES ('Orphan', 'Test', 'externo', ?, ?, datetime('now'))",
+            (email, f'6{abs(hash(email)) % 100000000:08d}')
         )
         return cursor.lastrowid
 
@@ -596,7 +596,7 @@ class TestNoOrphanedReservationOnUnavailableFurniture:
             count_before = cursor.fetchone()['cnt']
 
             # Second reservation on the same furniture/date must raise ValueError
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="Mobiliario no disponible"):
                 create_beach_reservation(
                     customer_id=cust2,
                     reservation_date='2099-06-15',


### PR DESCRIPTION
## Summary

- **Bug #45:** Added active-reservation conflict check to `create_furniture_block()` — previously, furniture blocks could silently overlap reservations in any non-releasing state
- **Bug #46:** Fixed premature transaction commit caused by nested `with get_db() as conn:` calls sharing the same `g.db` connection — added optional `conn=` parameter to `check_furniture_availability_bulk()` and passed outer `conn` from `create_beach_reservation` and `create_linked_multiday_reservations`
- **Bonus fixes:** Corrected `update_reservation_with_furniture` which was checking the wrong return key (`'conflicts'` vs `'unavailable'`) making its availability check a no-op; added `AND active = 1` consistency across all releasing-state queries

## Root Cause (Bug #46)

`get_db()` always returns the same `g.db` connection per Flask app context. Inside `create_beach_reservation`, a `BEGIN IMMEDIATE` transaction was opened, a reservation row inserted (uncommitted), then `check_furniture_availability_bulk` was called — which opened its own `with get_db() as conn:` on the same connection. When that inner block exited normally, Python's sqlite3 context manager called `conn.commit()`, prematurely committing the partial outer transaction. Subsequent `conn.rollback()` was then a no-op, leaving 537 orphaned reservations without furniture assignments.

## Verification

Fresh simulation (April 2026, 2,146 reservations at 80–100% occupancy):
- **Furniture blocks overlapping active reservations:** 0 (was 5 FAIL)
- **Active reservations with no furniture assignment:** 0 (was 537)
- Health check: 14 OK, 1 WARN (informational), 0 FAIL

## Test Plan
- [x] `TestCreateFurnitureBlockConflict` — 3 tests covering conflict detection and releasing-state bypass
- [x] `TestCheckFurnitureAvailabilityBulkWithConn` — 2 tests verifying `conn=` path identical to standalone
- [x] `TestNoOrphanedReservationOnUnavailableFurniture` — single-day orphan prevention
- [x] `TestNoOrphanedMultidayReservationOnUnavailableFurniture` — multi-day orphan prevention
- [x] 326/326 tests passing

Closes #45, Closes #46